### PR TITLE
chore: add gh body-file workflow skill

### DIFF
--- a/.github/skills/gh-body-file-workflow/SKILL.md
+++ b/.github/skills/gh-body-file-workflow/SKILL.md
@@ -19,6 +19,7 @@ Produce reliable `gh` commands for Issue/PR operations by writing body text to a
 - Do not pass long body text directly via stdin when reliability is important.
 - Always save body text to a file under `tmp/` or `.workspace/` first.
 - Always use `--body-file <path>` for `gh issue` and `gh pr` body content.
+- Delete temporary body files after successful command execution.
 
 ## Procedure
 1. Define the operation target.
@@ -83,9 +84,17 @@ gh pr edit 45 \
 - Confirm the command references the expected file.
 - For batch runs, ensure each title maps to the correct body file.
 
-6. Optional cleanup.
-- Remove transient files in `tmp/` after completion.
-- Keep reusable templates in `.workspace/` when future edits are expected.
+6. Cleanup (required).
+- Remove transient body files after successful command execution.
+- If the body file is temporary, delete it regardless of whether it was in `tmp/` or `.workspace/`.
+
+Example:
+```bash
+gh issue create \
+  --title "Create reusable profile editor" \
+  --body-file tmp/issue-geometry-editor.md && \
+rm -f tmp/issue-geometry-editor.md
+```
 
 ## Branching Rules
 - If the text is one short sentence and formatting risk is negligible, inline flags may be acceptable.
@@ -95,5 +104,5 @@ gh pr edit 45 \
 ## Completion Checks
 - Every `gh issue/pr` command includes `--body-file`.
 - No long Markdown body is passed by stdin.
-- Body files are stored under `tmp/` or `.workspace/`.
+- Temporary body files are deleted after command completion.
 - Command intent and file naming are traceable.


### PR DESCRIPTION
## Summary
- add a new reusable skill for GitHub CLI body handling: `gh-body-file-workflow`
- document a file-first workflow for Issue/PR body text (`tmp/` or `.workspace/`)
- standardize use of `--body-file` to avoid stdin formatting issues

## Why
Using stdin for multi-line Markdown bodies can sometimes break formatting in local shell flows. This skill provides a consistent, repeatable procedure to reduce those failures.

## Changes
- add `.github/skills/gh-body-file-workflow/SKILL.md`
- include:
  - when to use
  - required policy
  - step-by-step procedure
  - branching rules
  - completion checks

## Validation
- skill file created under `.github/skills/gh-body-file-workflow/`
- frontmatter includes `name`, `description`, and `argument-hint`
- workflow examples cover issue/pr create/edit with `--body-file`
