### PR TITLE
[codex] Add IfcCShapeProfileDef support for extrusions

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -6,6 +6,7 @@ import { booleanDifferenceSample } from "../ifc/samples/boolean.difference.ts";
 import { extrusionCircleSample } from "../ifc/samples/extrusion.circle.ts";
 import { extrusionRectHollowSample } from "../ifc/samples/extrusion.rect-hollow.ts";
 import { extrusionCircleHollowSample } from "../ifc/samples/extrusion.circle-hollow.ts";
+import { extrusionCShapeSample } from "../ifc/samples/extrusion.c-shape.ts";
 import { extrusionIShapeSample } from "../ifc/samples/extrusion.i-shape.ts";
 import { extrusionLShapeSample } from "../ifc/samples/extrusion.l-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
@@ -17,6 +18,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-circle": extrusionCircleSample,
   "extrusion-rect-hollow": extrusionRectHollowSample,
   "extrusion-circle-hollow": extrusionCircleHollowSample,
+  "extrusion-c-shape": extrusionCShapeSample,
   "extrusion-i-shape": extrusionIShapeSample,
   "extrusion-l-shape": extrusionLShapeSample,
   "swept-disk-basic": sweptDiskBasicSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -141,6 +141,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-c-shape",
+    title: "C-Shape Profile (IfcCShapeProfileDef)",
+    description:
+      "Extrudes a channel-shaped cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcCShapeProfileDef).",
+    sampleId: "extrusion-c-shape",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/extrusion-l-shape",
     title: "L-Shape Profile (IfcLShapeProfileDef)",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -200,6 +200,7 @@ export function defaultPlacement3D(): NormalizedPlacement3D {
 // ── Profile polygon helpers ───────────────────────────────────────────────
 
 const CIRCLE_SEGMENTS = 48
+const FILLET_SEGMENTS = 8
 
 function circleLoop(radius: number, segments = CIRCLE_SEGMENTS): NormalizedVec2[] {
   const pts: NormalizedVec2[] = []
@@ -208,6 +209,146 @@ function circleLoop(radius: number, segments = CIRCLE_SEGMENTS): NormalizedVec2[
     pts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius })
   }
   return pts
+}
+
+function polygonSignedArea(pts: NormalizedVec2[]): number {
+  let area = 0
+  for (let i = 0; i < pts.length; i++) {
+    const current = pts[i]
+    const next = pts[(i + 1) % pts.length]
+    area += current.x * next.y - next.x * current.y
+  }
+  return area / 2
+}
+
+function ensureCounterClockwise(pts: NormalizedVec2[]): NormalizedVec2[] {
+  return polygonSignedArea(pts) >= 0 ? pts : [...pts].reverse()
+}
+
+function appendArc(
+  pts: NormalizedVec2[],
+  centerX: number,
+  centerY: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+  segments = FILLET_SEGMENTS,
+): void {
+  for (let i = 1; i <= segments; i++) {
+    const t = i / segments
+    const angle = startAngle + (endAngle - startAngle) * t
+    pts.push({
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius,
+    })
+  }
+}
+
+function cShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'IfcCShapeProfileDef' }>): NormalizedVec2[] {
+  const hw = profile.width / 2
+  const hd = profile.depth / 2
+  const thickness = profile.wallThickness
+  const maxFilletRadius = Math.max(
+    0,
+    Math.min(
+      profile.girth - thickness,
+      (profile.width - 2 * thickness) / 2,
+      (profile.depth - 2 * thickness) / 2,
+    ),
+  )
+  const filletRadius = Math.min(profile.internalFilletRadius ?? 0, maxFilletRadius)
+
+  if (filletRadius <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: hd },
+      { x: hw, y: hd },
+      { x: hw, y: hd - profile.girth },
+      { x: hw - thickness, y: hd - profile.girth },
+      { x: hw - thickness, y: hd - thickness },
+      { x: -hw + thickness, y: hd - thickness },
+      { x: -hw + thickness, y: -hd + thickness },
+      { x: hw - thickness, y: -hd + thickness },
+      { x: hw - thickness, y: -hd + profile.girth },
+      { x: hw, y: -hd + profile.girth },
+      { x: hw, y: -hd },
+      { x: -hw, y: -hd },
+    ])
+  }
+
+  const rInner = filletRadius
+  const rOuter = rInner + thickness
+  const pts: NormalizedVec2[] = [
+    { x: -hw + rOuter, y: hd },
+    { x: hw - rOuter, y: hd },
+  ]
+
+  appendArc(pts, hw - rOuter, hd - rOuter, rOuter, Math.PI / 2, 0)
+  pts.push(
+    { x: hw, y: hd - profile.girth },
+    { x: hw - thickness, y: hd - profile.girth },
+    { x: hw - thickness, y: hd - thickness - rInner },
+  )
+  appendArc(
+    pts,
+    hw - thickness - rInner,
+    hd - thickness - rInner,
+    rInner,
+    0,
+    Math.PI / 2,
+  )
+  pts.push({ x: -hw + thickness + rInner, y: hd - thickness })
+  appendArc(
+    pts,
+    -hw + thickness + rInner,
+    hd - thickness - rInner,
+    rInner,
+    Math.PI / 2,
+    Math.PI,
+  )
+  pts.push({ x: -hw + thickness, y: -hd + thickness + rInner })
+  appendArc(
+    pts,
+    -hw + thickness + rInner,
+    -hd + thickness + rInner,
+    rInner,
+    Math.PI,
+    (3 * Math.PI) / 2,
+  )
+  pts.push({ x: hw - thickness - rInner, y: -hd + thickness })
+  appendArc(
+    pts,
+    hw - thickness - rInner,
+    -hd + thickness + rInner,
+    rInner,
+    (3 * Math.PI) / 2,
+    2 * Math.PI,
+  )
+  pts.push(
+    { x: hw - thickness, y: -hd + profile.girth },
+    { x: hw, y: -hd + profile.girth },
+    { x: hw, y: -hd + rOuter },
+  )
+  appendArc(pts, hw - rOuter, -hd + rOuter, rOuter, 0, -Math.PI / 2)
+  pts.push({ x: -hw + rOuter, y: -hd })
+  appendArc(
+    pts,
+    -hw + rOuter,
+    -hd + rOuter,
+    rOuter,
+    -Math.PI / 2,
+    -Math.PI,
+  )
+  pts.push({ x: -hw, y: hd - rOuter })
+  appendArc(
+    pts,
+    -hw + rOuter,
+    hd - rOuter,
+    rOuter,
+    Math.PI,
+    Math.PI / 2,
+  )
+
+  return ensureCounterClockwise(pts)
 }
 
 /**
@@ -233,7 +374,7 @@ function applyPlacement2DToLoop(
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
  * Supported types: Rectangle, Circle, RectangleHollow, CircleHollow,
- * IShape (symmetric), LShape.
+ * IShape (symmetric), LShape, CShape.
  * Other parameterized types throw an Error.
  */
 export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): NormalizedProfile {
@@ -280,6 +421,10 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
       innerLoops = [circleLoop(profile.radius - profile.wallThickness).reverse()]
       break
     }
+
+    case 'IfcCShapeProfileDef':
+      outerLoop = cShapeLoop(profile)
+      break
 
     case 'IfcIShapeProfileDef': {
       const hw  = profile.overallWidth / 2

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -347,6 +347,8 @@ function cShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'If
     Math.PI,
     Math.PI / 2,
   )
+  // The last arc ends at (-hw + rOuter, hd) which is identical to pts[0]; drop the duplicate.
+  pts.pop()
 
   return ensureCounterClockwise(pts)
 }

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -9,6 +9,7 @@ import type { Scene, StandardMaterial, Mesh, LinesMesh } from "@babylonjs/core";
 import earcut from "earcut";
 import type {
   IfcProfileDef,
+  IfcCShapeProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   Vec2,
@@ -25,6 +26,7 @@ import {
 } from "../../engine/ifc-coordinates.ts";
 
 const CIRCLE_SEGMENTS = 48;
+const FILLET_SEGMENTS = 8;
 
 function isIndexInRange(
   index: number,
@@ -43,6 +45,146 @@ function circleVec2(radius: number, segments = CIRCLE_SEGMENTS): Vec2[] {
     pts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
   }
   return pts;
+}
+
+function polygonSignedArea(pts: Vec2[]): number {
+  let area = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const current = pts[i];
+    const next = pts[(i + 1) % pts.length];
+    area += current.x * next.y - next.x * current.y;
+  }
+  return area / 2;
+}
+
+function ensureCounterClockwise(pts: Vec2[]): Vec2[] {
+  return polygonSignedArea(pts) >= 0 ? pts : [...pts].reverse();
+}
+
+function appendArc(
+  pts: Vec2[],
+  centerX: number,
+  centerY: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+  segments = FILLET_SEGMENTS,
+): void {
+  for (let i = 1; i <= segments; i++) {
+    const t = i / segments;
+    const angle = startAngle + (endAngle - startAngle) * t;
+    pts.push({
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius,
+    });
+  }
+}
+
+function cShapeVec2(p: IfcCShapeProfileDef): Vec2[] {
+  const hw = p.width / 2;
+  const hd = p.depth / 2;
+  const thickness = p.wallThickness;
+  const maxFilletRadius = Math.max(
+    0,
+    Math.min(
+      p.girth - thickness,
+      (p.width - 2 * thickness) / 2,
+      (p.depth - 2 * thickness) / 2,
+    ),
+  );
+  const filletRadius = Math.min(p.internalFilletRadius ?? 0, maxFilletRadius);
+
+  if (filletRadius <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: hd },
+      { x: hw, y: hd },
+      { x: hw, y: hd - p.girth },
+      { x: hw - thickness, y: hd - p.girth },
+      { x: hw - thickness, y: hd - thickness },
+      { x: -hw + thickness, y: hd - thickness },
+      { x: -hw + thickness, y: -hd + thickness },
+      { x: hw - thickness, y: -hd + thickness },
+      { x: hw - thickness, y: -hd + p.girth },
+      { x: hw, y: -hd + p.girth },
+      { x: hw, y: -hd },
+      { x: -hw, y: -hd },
+    ]);
+  }
+
+  const rInner = filletRadius;
+  const rOuter = rInner + thickness;
+  const pts: Vec2[] = [
+    { x: -hw + rOuter, y: hd },
+    { x: hw - rOuter, y: hd },
+  ];
+
+  appendArc(pts, hw - rOuter, hd - rOuter, rOuter, Math.PI / 2, 0);
+  pts.push(
+    { x: hw, y: hd - p.girth },
+    { x: hw - thickness, y: hd - p.girth },
+    { x: hw - thickness, y: hd - thickness - rInner },
+  );
+  appendArc(
+    pts,
+    hw - thickness - rInner,
+    hd - thickness - rInner,
+    rInner,
+    0,
+    Math.PI / 2,
+  );
+  pts.push({ x: -hw + thickness + rInner, y: hd - thickness });
+  appendArc(
+    pts,
+    -hw + thickness + rInner,
+    hd - thickness - rInner,
+    rInner,
+    Math.PI / 2,
+    Math.PI,
+  );
+  pts.push({ x: -hw + thickness, y: -hd + thickness + rInner });
+  appendArc(
+    pts,
+    -hw + thickness + rInner,
+    -hd + thickness + rInner,
+    rInner,
+    Math.PI,
+    (3 * Math.PI) / 2,
+  );
+  pts.push({ x: hw - thickness - rInner, y: -hd + thickness });
+  appendArc(
+    pts,
+    hw - thickness - rInner,
+    -hd + thickness + rInner,
+    rInner,
+    (3 * Math.PI) / 2,
+    2 * Math.PI,
+  );
+  pts.push(
+    { x: hw - thickness, y: -hd + p.girth },
+    { x: hw, y: -hd + p.girth },
+    { x: hw, y: -hd + rOuter },
+  );
+  appendArc(pts, hw - rOuter, -hd + rOuter, rOuter, 0, -Math.PI / 2);
+  pts.push({ x: -hw + rOuter, y: -hd });
+  appendArc(
+    pts,
+    -hw + rOuter,
+    -hd + rOuter,
+    rOuter,
+    -Math.PI / 2,
+    -Math.PI,
+  );
+  pts.push({ x: -hw, y: hd - rOuter });
+  appendArc(
+    pts,
+    -hw + rOuter,
+    hd - rOuter,
+    rOuter,
+    Math.PI,
+    Math.PI / 2,
+  );
+
+  return ensureCounterClockwise(pts);
 }
 
 function iShapeVec2(p: IfcIShapeProfileDef): Vec2[] {
@@ -110,6 +252,8 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
       return circleVec2(profile.radius);
     case "IfcCircleHollowProfileDef":
       return circleVec2(profile.radius);
+    case "IfcCShapeProfileDef":
+      return cShapeVec2(profile);
     case "IfcIShapeProfileDef":
       return iShapeVec2(profile);
     case "IfcLShapeProfileDef":

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -183,6 +183,8 @@ function cShapeVec2(p: IfcCShapeProfileDef): Vec2[] {
     Math.PI,
     Math.PI / 2,
   );
+  // The last arc ends at (-hw + rOuter, hd) which is identical to pts[0]; drop the duplicate.
+  pts.pop();
 
   return ensureCounterClockwise(pts);
 }

--- a/src/ifc/samples/extrusion.c-shape.ts
+++ b/src/ifc/samples/extrusion.c-shape.ts
@@ -1,0 +1,230 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcCShapeProfileDef",
+  profileType: "AREA",
+  depth: 5,
+  width: 3,
+  wallThickness: 0.35,
+  girth: 1.3,
+  internalFilletRadius: 0.15,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 6,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionCShapeSample: SampleDef = {
+  id: "extrusion-c-shape",
+  title: "C-Shape / Channel Profile (IfcCShapeProfileDef)",
+  description:
+    "A channel-shaped cross-section defined by overall depth, width, wall thickness, girth, and optional internal fillet radius (IfcCShapeProfileDef). " +
+    "Adjust the dimensions in the profile editor.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: C-Shape Cross-Section",
+      description:
+        "IfcCShapeProfileDef defines a channel-shaped section with a web on one side and two flanges returning inward. " +
+        "Girth controls the flange reach measured from the outer top and bottom edges.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector specifies where the C-shaped profile is swept. " +
+        "Use this step to inspect direction and depth before generating the final solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The C-shaped cross-section is extruded along the Z-axis to produce a 3D solid (IfcExtrudedAreaSolid).",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["c-shape"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const cDepth =
+      activeProfile.type === "IfcCShapeProfileDef"
+        ? activeProfile.depth
+        : DEFAULT_PROFILE.depth;
+    const width =
+      activeProfile.type === "IfcCShapeProfileDef"
+        ? activeProfile.width
+        : DEFAULT_PROFILE.width;
+    const wallThickness =
+      activeProfile.type === "IfcCShapeProfileDef"
+        ? activeProfile.wallThickness
+        : DEFAULT_PROFILE.wallThickness;
+    const girth =
+      activeProfile.type === "IfcCShapeProfileDef"
+        ? activeProfile.girth
+        : DEFAULT_PROFILE.girth;
+    const internalFilletRadius =
+      activeProfile.type === "IfcCShapeProfileDef"
+        ? activeProfile.internalFilletRadius
+        : DEFAULT_PROFILE.internalFilletRadius;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcCShapeProfileDef",
+        profileType: "AREA",
+        depth: cDepth,
+        width,
+        wallThickness,
+        girth,
+        ...(internalFilletRadius && internalFilletRadius > 0
+          ? { internalFilletRadius }
+          : {}),
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, activeProfile, "cshape_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcCShapeProfileDef",
+      profileType: "AREA",
+      depth: "(see profile editor)",
+      width: "(see profile editor)",
+      wallThickness: "(see profile editor)",
+      girth: "(see profile editor)",
+      internalFilletRadius: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/ifc/schema.ts
+++ b/src/ifc/schema.ts
@@ -23,6 +23,7 @@ export type {
 } from "../types.ts";
 
 export type {
+  IfcCShapeProfileDef,
   IfcRectangleProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type {
   IfcAreaParameterizedProfileDef,
   IfcParameterizedProfileDef,
   IfcProfileTypeEnum,
+  IfcCShapeProfileDef,
   IfcRectangleProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,
@@ -162,6 +163,7 @@ export type ProfileType =
   | "circle"
   | "rect-hollow"
   | "circle-hollow"
+  | "c-shape"
   | "i-shape"
   | "l-shape"
   | "arbitrary";

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -4,6 +4,7 @@ import type {
   IfcCircleProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleHollowProfileDef,
+  IfcCShapeProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   IfcArbitraryClosedProfileDef,
@@ -62,6 +63,8 @@ export class ProfileEditor {
         return "rect-hollow";
       case "IfcCircleHollowProfileDef":
         return "circle-hollow";
+      case "IfcCShapeProfileDef":
+        return "c-shape";
       case "IfcIShapeProfileDef":
         return "i-shape";
       case "IfcLShapeProfileDef":
@@ -109,6 +112,17 @@ export class ProfileEditor {
           radius: 2,
           wallThickness: 0.3,
         } satisfies IfcCircleHollowProfileDef);
+        break;
+      case "c-shape":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcCShapeProfileDef",
+          profileType: "AREA",
+          depth: 5,
+          width: 3,
+          wallThickness: 0.35,
+          girth: 1.3,
+          internalFilletRadius: 0.15,
+        } satisfies IfcCShapeProfileDef);
         break;
       case "i-shape":
         this.currentProfile = this._cloneProfile({
@@ -179,6 +193,41 @@ export class ProfileEditor {
       return `
         ${this._sliderHTML("ch-r", "Radius", p.radius, 0.5, 10, 0.1)}
         ${this._sliderHTML("ch-t", "Wall Thickness", chWall, chWallMin, chWallMax, 0.05)}
+      `;
+    }
+
+    if (p.type === "IfcCShapeProfileDef") {
+      const csWallMin = 0.05;
+      const csWallRawMax = Math.min(p.width / 2, p.depth / 2) - csWallMin;
+      const csWallMax = Math.max(csWallMin, csWallRawMax);
+      const csWall = Math.min(Math.max(p.wallThickness, csWallMin), csWallMax);
+      p.wallThickness = csWall;
+
+      const csGirthMin = csWall + 0.05;
+      const csGirthRawMax = p.depth / 2;
+      const csGirthMax = Math.max(csGirthMin, csGirthRawMax);
+      const csGirth = Math.min(Math.max(p.girth, csGirthMin), csGirthMax);
+      p.girth = csGirth;
+
+      const csFilletMin = 0;
+      const csFilletRawMax = Math.min(
+        csGirth - csWall,
+        (p.width - 2 * csWall) / 2,
+        (p.depth - 2 * csWall) / 2,
+      );
+      const csFilletMax = Math.max(csFilletMin, csFilletRawMax);
+      const csFillet = Math.min(
+        Math.max(p.internalFilletRadius ?? 0, csFilletMin),
+        csFilletMax,
+      );
+      p.internalFilletRadius = csFillet;
+
+      return `
+        ${this._sliderHTML("cs-d", "Depth", p.depth, 1, 10, 0.1)}
+        ${this._sliderHTML("cs-w", "Width", p.width, 0.5, 10, 0.1)}
+        ${this._sliderHTML("cs-t", "Wall Thickness", csWall, csWallMin, csWallMax, 0.05)}
+        ${this._sliderHTML("cs-g", "Girth", csGirth, csGirthMin, csGirthMax, 0.05)}
+        ${this._sliderHTML("cs-r", "Internal Fillet", csFillet, csFilletMin, csFilletMax, 0.05)}
       `;
     }
 
@@ -278,6 +327,7 @@ export class ProfileEditor {
       circle: "Circle",
       "rect-hollow": "Rect Hollow",
       "circle-hollow": "Circle Hollow",
+      "c-shape": "C-Shape",
       "i-shape": "I-Shape",
       "l-shape": "L-Shape",
       arbitrary: "Arbitrary",
@@ -358,6 +408,41 @@ export class ProfileEditor {
     });
     this._bindSlider("ch-t", (v) => {
       (this.currentProfile as IfcCircleHollowProfileDef).wallThickness = v;
+    });
+
+    // ── C-Shape ──
+    this._bindSlider("cs-d", (v) => {
+      const prof = this.currentProfile as IfcCShapeProfileDef;
+      prof.depth = v;
+      const wallMax = Math.max(0.05, Math.min(prof.width / 2, prof.depth / 2) - 0.05);
+      prof.wallThickness = this._clampDependentSlider("cs-t", wallMax);
+      const girthMin = prof.wallThickness + 0.05;
+      const girthMax = Math.max(girthMin, prof.depth / 2);
+      prof.girth = Math.max(girthMin, this._clampDependentSlider("cs-g", girthMax));
+      prof.internalFilletRadius = this._clampCShapeFilletRadius();
+    });
+    this._bindSlider("cs-w", (v) => {
+      const prof = this.currentProfile as IfcCShapeProfileDef;
+      prof.width = v;
+      const wallMax = Math.max(0.05, Math.min(prof.width / 2, prof.depth / 2) - 0.05);
+      prof.wallThickness = this._clampDependentSlider("cs-t", wallMax);
+      prof.internalFilletRadius = this._clampCShapeFilletRadius();
+    });
+    this._bindSlider("cs-t", (v) => {
+      const prof = this.currentProfile as IfcCShapeProfileDef;
+      prof.wallThickness = v;
+      const girthMin = prof.wallThickness + 0.05;
+      const girthMax = Math.max(girthMin, prof.depth / 2);
+      prof.girth = Math.max(girthMin, this._clampDependentSlider("cs-g", girthMax));
+      prof.internalFilletRadius = this._clampCShapeFilletRadius();
+    });
+    this._bindSlider("cs-g", (v) => {
+      const prof = this.currentProfile as IfcCShapeProfileDef;
+      prof.girth = v;
+      prof.internalFilletRadius = this._clampCShapeFilletRadius();
+    });
+    this._bindSlider("cs-r", (v) => {
+      (this.currentProfile as IfcCShapeProfileDef).internalFilletRadius = v;
     });
 
     // ── I-Shape ──
@@ -483,5 +568,19 @@ export class ProfileEditor {
       return safeMax;
     }
     return current;
+  }
+
+  private _clampCShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcCShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const max = Math.max(
+      0,
+      Math.min(
+        prof.girth - prof.wallThickness,
+        (prof.width - 2 * prof.wallThickness) / 2,
+        (prof.depth - 2 * prof.wallThickness) / 2,
+      ),
+    );
+    return this._clampDependentSlider("cs-r", max);
   }
 }


### PR DESCRIPTION
## Summary
- add `IfcCShapeProfileDef` support to the `IfcExtrudedAreaSolid` path
- implement C-shape profile loop generation in both the extrusion operation and normalization layer
- add a new playground sample and profile editor controls for C-shape parameters

## Why
`IfcExtrudedAreaSolid` in the playground supported several parameterized profiles, but not `IfcCShapeProfileDef`. This change adds the missing profile so channel sections can be explored and rendered consistently.

## Validation
- `bun run build`