### PR TITLE
[codex] Add ellipse profile support for extruded area solids

### DIFF
--- a/docs/ifc-geometry-types.md
+++ b/docs/ifc-geometry-types.md
@@ -268,7 +268,7 @@ IfcOpenShell のスキーマを基に、IFC で扱われるジオメトリ種類
 | `IfcCircleProfileDef` | 円形 | `Radius` | 🔨 |
 | `IfcCircleHollowProfileDef` | 円形中空（丸パイプ） | `Radius`, `WallThickness` | 🔨 |
 | `IfcRoundedRectangleProfileDef` | 角丸矩形 | `XDim`, `YDim`, `RoundingRadius` | 📋 |
-| `IfcEllipseProfileDef` | 楕円形 | `SemiAxis1`, `SemiAxis2` | 📋 |
+| `IfcEllipseProfileDef` | 楕円形 | `SemiAxis1`, `SemiAxis2` | ✅ |
 | `IfcTrapeziumProfileDef` | 台形 | `BottomXDim`, `TopXDim`, `YDim`, `TopXOffset` | 📋 |
 
 ### 5.2 鋼材断面プロファイル

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -4,6 +4,7 @@ import { ExamplePage } from "../pages/ExamplePage.ts";
 import { extrusionRectangleSample } from "../ifc/samples/extrusion.rectangle.ts";
 import { booleanDifferenceSample } from "../ifc/samples/boolean.difference.ts";
 import { extrusionCircleSample } from "../ifc/samples/extrusion.circle.ts";
+import { extrusionEllipseSample } from "../ifc/samples/extrusion.ellipse.ts";
 import { extrusionRectHollowSample } from "../ifc/samples/extrusion.rect-hollow.ts";
 import { extrusionCircleHollowSample } from "../ifc/samples/extrusion.circle-hollow.ts";
 import { extrusionCShapeSample } from "../ifc/samples/extrusion.c-shape.ts";
@@ -16,6 +17,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-rectangle": extrusionRectangleSample,
   "boolean-difference": booleanDifferenceSample,
   "extrusion-circle": extrusionCircleSample,
+  "extrusion-ellipse": extrusionEllipseSample,
   "extrusion-rect-hollow": extrusionRectHollowSample,
   "extrusion-circle-hollow": extrusionCircleHollowSample,
   "extrusion-c-shape": extrusionCShapeSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -111,6 +111,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-ellipse",
+    title: "Ellipse Profile (IfcEllipseProfileDef)",
+    description:
+      "Extrudes an elliptical cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcEllipseProfileDef).",
+    sampleId: "extrusion-ellipse",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/extrusion-rect-hollow",
     title: "Rectangular Hollow Section (IfcRectangleHollowProfileDef)",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -211,6 +211,22 @@ function circleLoop(radius: number, segments = CIRCLE_SEGMENTS): NormalizedVec2[
   return pts
 }
 
+function ellipseLoop(
+  semiAxis1: number,
+  semiAxis2: number,
+  segments = CIRCLE_SEGMENTS,
+): NormalizedVec2[] {
+  const pts: NormalizedVec2[] = []
+  for (let i = 0; i < segments; i++) {
+    const angle = (i / segments) * Math.PI * 2
+    pts.push({
+      x: Math.cos(angle) * semiAxis1,
+      y: Math.sin(angle) * semiAxis2,
+    })
+  }
+  return pts
+}
+
 function polygonSignedArea(pts: NormalizedVec2[]): number {
   let area = 0
   for (let i = 0; i < pts.length; i++) {
@@ -375,8 +391,8 @@ function applyPlacement2DToLoop(
  * Normalize a generated-schema area profile into outer/inner planar loops.
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
- * Supported types: Rectangle, Circle, RectangleHollow, CircleHollow,
- * IShape (symmetric), LShape, CShape.
+ * Supported types: Rectangle, Circle, Ellipse, RectangleHollow,
+ * CircleHollow, IShape (symmetric), LShape, CShape.
  * Other parameterized types throw an Error.
  */
 export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): NormalizedProfile {
@@ -400,6 +416,10 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
 
     case 'IfcCircleProfileDef':
       outerLoop = circleLoop(profile.radius)
+      break
+
+    case 'IfcEllipseProfileDef':
+      outerLoop = ellipseLoop(profile.semiAxis1, profile.semiAxis2)
       break
 
     case 'IfcRectangleHollowProfileDef': {

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -47,6 +47,22 @@ function circleVec2(radius: number, segments = CIRCLE_SEGMENTS): Vec2[] {
   return pts;
 }
 
+function ellipseVec2(
+  semiAxis1: number,
+  semiAxis2: number,
+  segments = CIRCLE_SEGMENTS,
+): Vec2[] {
+  const pts: Vec2[] = [];
+  for (let i = 0; i < segments; i++) {
+    const angle = (i / segments) * Math.PI * 2;
+    pts.push({
+      x: Math.cos(angle) * semiAxis1,
+      y: Math.sin(angle) * semiAxis2,
+    });
+  }
+  return pts;
+}
+
 function polygonSignedArea(pts: Vec2[]): number {
   let area = 0;
   for (let i = 0; i < pts.length; i++) {
@@ -252,6 +268,8 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
     }
     case "IfcCircleProfileDef":
       return circleVec2(profile.radius);
+    case "IfcEllipseProfileDef":
+      return ellipseVec2(profile.semiAxis1, profile.semiAxis2);
     case "IfcCircleHollowProfileDef":
       return circleVec2(profile.radius);
     case "IfcCShapeProfileDef":

--- a/src/ifc/samples/extrusion.ellipse.ts
+++ b/src/ifc/samples/extrusion.ellipse.ts
@@ -1,0 +1,208 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcEllipseProfileDef",
+  profileType: "AREA",
+  semiAxis1: 3,
+  semiAxis2: 2,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 5,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionEllipseSample: SampleDef = {
+  id: "extrusion-ellipse",
+  title: "Ellipse Profile (IfcEllipseProfileDef)",
+  description:
+    "An elliptical cross-section extruded into a 3D solid using IfcExtrudedAreaSolid. " +
+    "Adjust the two semi-axes in the profile editor and extrusion settings below.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: Ellipse Profile",
+      description:
+        "IfcEllipseProfileDef defines an elliptical cross-section by semiAxis1 and semiAxis2. " +
+        "Edit both semi-axes using the profile editor above.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector specifies where the elliptical profile will be swept. " +
+        "Adjust direction and depth to inspect the setup before creating the final solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The ellipse is extruded along the Z-axis by the given depth to produce an elliptical cylinder. " +
+        "This is equivalent to IfcExtrudedAreaSolid applied to an IfcEllipseProfileDef.",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["ellipse"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const semiAxis1 =
+      activeProfile.type === "IfcEllipseProfileDef"
+        ? activeProfile.semiAxis1
+        : DEFAULT_PROFILE.semiAxis1;
+    const semiAxis2 =
+      activeProfile.type === "IfcEllipseProfileDef"
+        ? activeProfile.semiAxis2
+        : DEFAULT_PROFILE.semiAxis2;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcEllipseProfileDef",
+        profileType: "AREA",
+        semiAxis1,
+        semiAxis2,
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, activeProfile, "ellipse_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcEllipseProfileDef",
+      profileType: "AREA",
+      semiAxis1: "(see profile editor)",
+      semiAxis2: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/ifc/schema.ts
+++ b/src/ifc/schema.ts
@@ -28,6 +28,7 @@ export type {
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,
   IfcCircleHollowProfileDef,
+  IfcEllipseProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
 } from "./generated/schema.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type {
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,
   IfcCircleHollowProfileDef,
+  IfcEllipseProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
 } from "./ifc/generated/schema.ts";
@@ -161,6 +162,7 @@ export interface StepDef {
 export type ProfileType =
   | "rectangle"
   | "circle"
+  | "ellipse"
   | "rect-hollow"
   | "circle-hollow"
   | "c-shape"

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -2,6 +2,7 @@ import type {
   IfcProfileDef,
   IfcRectangleProfileDef,
   IfcCircleProfileDef,
+  IfcEllipseProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleHollowProfileDef,
   IfcCShapeProfileDef,
@@ -59,6 +60,8 @@ export class ProfileEditor {
         return "rectangle";
       case "IfcCircleProfileDef":
         return "circle";
+      case "IfcEllipseProfileDef":
+        return "ellipse";
       case "IfcRectangleHollowProfileDef":
         return "rect-hollow";
       case "IfcCircleHollowProfileDef":
@@ -95,6 +98,14 @@ export class ProfileEditor {
           profileType: "AREA",
           radius: 2,
         } satisfies IfcCircleProfileDef);
+        break;
+      case "ellipse":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcEllipseProfileDef",
+          profileType: "AREA",
+          semiAxis1: 3,
+          semiAxis2: 2,
+        } satisfies IfcEllipseProfileDef);
         break;
       case "rect-hollow":
         this.currentProfile = this._cloneProfile({
@@ -169,6 +180,13 @@ export class ProfileEditor {
 
     if (p.type === "IfcCircleProfileDef") {
       return this._sliderHTML("circle-r", "Radius", p.radius, 0.1, 10, 0.1);
+    }
+
+    if (p.type === "IfcEllipseProfileDef") {
+      return `
+        ${this._sliderHTML("ellipse-a", "Semi Axis 1", p.semiAxis1, 0.1, 10, 0.1)}
+        ${this._sliderHTML("ellipse-b", "Semi Axis 2", p.semiAxis2, 0.1, 10, 0.1)}
+      `;
     }
 
     if (p.type === "IfcRectangleHollowProfileDef") {
@@ -325,6 +343,7 @@ export class ProfileEditor {
     const labels: Record<ProfileType, string> = {
       rectangle: "Rectangle",
       circle: "Circle",
+      ellipse: "Ellipse",
       "rect-hollow": "Rect Hollow",
       "circle-hollow": "Circle Hollow",
       "c-shape": "C-Shape",
@@ -380,6 +399,14 @@ export class ProfileEditor {
     // ── Circle ──
     this._bindSlider("circle-r", (v) => {
       (this.currentProfile as IfcCircleProfileDef).radius = v;
+    });
+
+    // ── Ellipse ──
+    this._bindSlider("ellipse-a", (v) => {
+      (this.currentProfile as IfcEllipseProfileDef).semiAxis1 = v;
+    });
+    this._bindSlider("ellipse-b", (v) => {
+      (this.currentProfile as IfcEllipseProfileDef).semiAxis2 = v;
     });
 
     // ── Rectangle Hollow ──


### PR DESCRIPTION
## Summary
- add `IfcEllipseProfileDef` support to extrusion profile normalization and outline generation
- extend the profile editor and type exports so ellipse profiles can be edited in the playground UI
- add an `extrusion-ellipse` sample and route, and mark `IfcEllipseProfileDef` as supported in the docs

## Why
The playground already supported several `IfcExtrudedAreaSolid` profile types, but `IfcEllipseProfileDef` was still missing. That meant ellipse-based extrusions could not be previewed, edited, or demonstrated end-to-end.

## Impact
Users can now inspect and edit ellipse profiles in the playground and generate `IfcExtrudedAreaSolid` geometry from `IfcEllipseProfileDef`.

## Validation
- `bun run build`