### PR TITLE
[codex] Add IfcTShapeProfileDef extrusion support

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -10,6 +10,7 @@ import { extrusionCircleHollowSample } from "../ifc/samples/extrusion.circle-hol
 import { extrusionCShapeSample } from "../ifc/samples/extrusion.c-shape.ts";
 import { extrusionIShapeSample } from "../ifc/samples/extrusion.i-shape.ts";
 import { extrusionLShapeSample } from "../ifc/samples/extrusion.l-shape.ts";
+import { extrusionTShapeSample } from "../ifc/samples/extrusion.t-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import type { SampleDef } from "../types.ts";
 
@@ -23,6 +24,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-c-shape": extrusionCShapeSample,
   "extrusion-i-shape": extrusionIShapeSample,
   "extrusion-l-shape": extrusionLShapeSample,
+  "extrusion-t-shape": extrusionTShapeSample,
   "swept-disk-basic": sweptDiskBasicSample,
 };
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -171,6 +171,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-t-shape",
+    title: "T-Shape Profile (IfcTShapeProfileDef)",
+    description:
+      "Extrudes a T-shaped cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcTShapeProfileDef).",
+    sampleId: "extrusion-t-shape",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/tessellation",
     title: "Triangulated Face Set",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -501,7 +501,7 @@ function applyPlacement2DToLoop(
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
  * Supported types: Rectangle, Circle, Ellipse, RectangleHollow,
- * CircleHollow, IShape (symmetric), LShape, CShape.
+ * CircleHollow, IShape (symmetric), TShape, LShape, CShape.
  * Other parameterized types throw an Error.
  */
 export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): NormalizedProfile {

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -369,6 +369,115 @@ function cShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'If
   return ensureCounterClockwise(pts)
 }
 
+function tShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'IfcTShapeProfileDef' }>): NormalizedVec2[] {
+  const hw = profile.flangeWidth / 2
+  const hd = profile.depth / 2
+  const hweb = profile.webThickness / 2
+  const yTop = hd
+  const yFlangeBottom = hd - profile.flangeThickness
+  const yBottom = -hd
+  const flangeSpan = Math.max(0, hw - hweb)
+  const webHeight = Math.max(0, profile.depth - profile.flangeThickness)
+  const rFillet = Math.min(
+    profile.filletRadius ?? 0,
+    flangeSpan,
+    profile.flangeThickness,
+    webHeight,
+  )
+  const rFlange = Math.min(
+    profile.flangeEdgeRadius ?? 0,
+    profile.flangeThickness,
+    Math.max(0, flangeSpan - rFillet),
+  )
+  const rWeb = Math.min(
+    profile.webEdgeRadius ?? 0,
+    hweb,
+    Math.max(0, webHeight - rFillet),
+  )
+
+  if (rFillet <= 1e-6 && rFlange <= 1e-6 && rWeb <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: hw, y: yTop },
+      { x: hw, y: yFlangeBottom },
+      { x: hweb, y: yFlangeBottom },
+      { x: hweb, y: yBottom },
+      { x: -hweb, y: yBottom },
+      { x: -hweb, y: yFlangeBottom },
+      { x: -hw, y: yFlangeBottom },
+      { x: -hw, y: yTop },
+    ])
+  }
+
+  const pts: NormalizedVec2[] = [{ x: hw, y: yTop }]
+
+  if (rFlange > 1e-6) {
+    pts.push({ x: hw, y: yFlangeBottom + rFlange })
+    appendArc(pts, hw - rFlange, yFlangeBottom + rFlange, rFlange, 0, -Math.PI / 2)
+  } else {
+    pts.push({ x: hw, y: yFlangeBottom })
+  }
+
+  if (rFillet > 1e-6) {
+    pts.push({ x: hweb + rFillet, y: yFlangeBottom })
+    appendArc(
+      pts,
+      hweb + rFillet,
+      yFlangeBottom - rFillet,
+      rFillet,
+      Math.PI / 2,
+      Math.PI,
+    )
+  } else {
+    pts.push({ x: hweb, y: yFlangeBottom })
+  }
+
+  if (rWeb > 1e-6) {
+    pts.push({ x: hweb, y: yBottom + rWeb })
+    appendArc(pts, hweb - rWeb, yBottom + rWeb, rWeb, 0, -Math.PI / 2)
+  } else {
+    pts.push({ x: hweb, y: yBottom })
+  }
+
+  if (rWeb > 1e-6) {
+    pts.push({ x: -hweb + rWeb, y: yBottom })
+    appendArc(pts, -hweb + rWeb, yBottom + rWeb, rWeb, -Math.PI / 2, -Math.PI)
+  } else {
+    pts.push({ x: -hweb, y: yBottom })
+  }
+
+  if (rFillet > 1e-6) {
+    pts.push({ x: -hweb, y: yFlangeBottom - rFillet })
+    appendArc(
+      pts,
+      -hweb - rFillet,
+      yFlangeBottom - rFillet,
+      rFillet,
+      0,
+      Math.PI / 2,
+    )
+  } else {
+    pts.push({ x: -hweb, y: yFlangeBottom })
+  }
+
+  if (rFlange > 1e-6) {
+    pts.push({ x: -hw + rFlange, y: yFlangeBottom })
+    appendArc(
+      pts,
+      -hw + rFlange,
+      yFlangeBottom + rFlange,
+      rFlange,
+      -Math.PI / 2,
+      -Math.PI,
+    )
+  } else {
+    pts.push({ x: -hw, y: yFlangeBottom })
+  }
+
+  pts.push({ x: -hw, y: yTop })
+
+  return ensureCounterClockwise(pts)
+}
+
 /**
  * Apply a 2D placement transform to a list of profile-space points.
  * The Y axis is the 90° CCW rotation of the X axis.
@@ -469,6 +578,10 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
       ]
       break
     }
+
+    case 'IfcTShapeProfileDef':
+      outerLoop = tShapeLoop(profile)
+      break
 
     case 'IfcLShapeProfileDef': {
       // Per IFC spec, width is optional; when omitted the L-shape is symmetric

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -12,6 +12,7 @@ import type {
   IfcCShapeProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
+  IfcTShapeProfileDef,
   Vec2,
 } from "../../types.ts";
 import {
@@ -241,6 +242,115 @@ function lShapeVec2(p: IfcLShapeProfileDef): Vec2[] {
   ];
 }
 
+function tShapeVec2(p: IfcTShapeProfileDef): Vec2[] {
+  const hw = p.flangeWidth / 2;
+  const hd = p.depth / 2;
+  const hweb = p.webThickness / 2;
+  const yTop = hd;
+  const yFlangeBottom = hd - p.flangeThickness;
+  const yBottom = -hd;
+  const flangeSpan = Math.max(0, hw - hweb);
+  const webHeight = Math.max(0, p.depth - p.flangeThickness);
+  const rFillet = Math.min(
+    p.filletRadius ?? 0,
+    flangeSpan,
+    p.flangeThickness,
+    webHeight,
+  );
+  const rFlange = Math.min(
+    p.flangeEdgeRadius ?? 0,
+    p.flangeThickness,
+    Math.max(0, flangeSpan - rFillet),
+  );
+  const rWeb = Math.min(
+    p.webEdgeRadius ?? 0,
+    hweb,
+    Math.max(0, webHeight - rFillet),
+  );
+
+  if (rFillet <= 1e-6 && rFlange <= 1e-6 && rWeb <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: hw, y: yTop },
+      { x: hw, y: yFlangeBottom },
+      { x: hweb, y: yFlangeBottom },
+      { x: hweb, y: yBottom },
+      { x: -hweb, y: yBottom },
+      { x: -hweb, y: yFlangeBottom },
+      { x: -hw, y: yFlangeBottom },
+      { x: -hw, y: yTop },
+    ]);
+  }
+
+  const pts: Vec2[] = [{ x: hw, y: yTop }];
+
+  if (rFlange > 1e-6) {
+    pts.push({ x: hw, y: yFlangeBottom + rFlange });
+    appendArc(pts, hw - rFlange, yFlangeBottom + rFlange, rFlange, 0, -Math.PI / 2);
+  } else {
+    pts.push({ x: hw, y: yFlangeBottom });
+  }
+
+  if (rFillet > 1e-6) {
+    pts.push({ x: hweb + rFillet, y: yFlangeBottom });
+    appendArc(
+      pts,
+      hweb + rFillet,
+      yFlangeBottom - rFillet,
+      rFillet,
+      Math.PI / 2,
+      Math.PI,
+    );
+  } else {
+    pts.push({ x: hweb, y: yFlangeBottom });
+  }
+
+  if (rWeb > 1e-6) {
+    pts.push({ x: hweb, y: yBottom + rWeb });
+    appendArc(pts, hweb - rWeb, yBottom + rWeb, rWeb, 0, -Math.PI / 2);
+  } else {
+    pts.push({ x: hweb, y: yBottom });
+  }
+
+  if (rWeb > 1e-6) {
+    pts.push({ x: -hweb + rWeb, y: yBottom });
+    appendArc(pts, -hweb + rWeb, yBottom + rWeb, rWeb, -Math.PI / 2, -Math.PI);
+  } else {
+    pts.push({ x: -hweb, y: yBottom });
+  }
+
+  if (rFillet > 1e-6) {
+    pts.push({ x: -hweb, y: yFlangeBottom - rFillet });
+    appendArc(
+      pts,
+      -hweb - rFillet,
+      yFlangeBottom - rFillet,
+      rFillet,
+      0,
+      Math.PI / 2,
+    );
+  } else {
+    pts.push({ x: -hweb, y: yFlangeBottom });
+  }
+
+  if (rFlange > 1e-6) {
+    pts.push({ x: -hw + rFlange, y: yFlangeBottom });
+    appendArc(
+      pts,
+      -hw + rFlange,
+      yFlangeBottom + rFlange,
+      rFlange,
+      -Math.PI / 2,
+      -Math.PI,
+    );
+  } else {
+    pts.push({ x: -hw, y: yFlangeBottom });
+  }
+
+  pts.push({ x: -hw, y: yTop });
+
+  return ensureCounterClockwise(pts);
+}
+
 // ── Public polygon accessors ───────────────────────────────────────────────
 
 /** Outer boundary of any profile as Vec2 list. */
@@ -278,6 +388,8 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
       return iShapeVec2(profile);
     case "IfcLShapeProfileDef":
       return lShapeVec2(profile);
+    case "IfcTShapeProfileDef":
+      return tShapeVec2(profile);
     case "IfcArbitraryClosedProfileDef":
     case "IfcArbitraryProfileDefWithVoids":
       return profile.outerCurve;

--- a/src/ifc/samples/extrusion.t-shape.ts
+++ b/src/ifc/samples/extrusion.t-shape.ts
@@ -1,0 +1,221 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcTShapeProfileDef",
+  profileType: "AREA",
+  depth: 5,
+  flangeWidth: 4,
+  webThickness: 0.8,
+  flangeThickness: 1.2,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 6,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionTShapeSample: SampleDef = {
+  id: "extrusion-t-shape",
+  title: "T-Shape / Tee Profile (IfcTShapeProfileDef)",
+  description:
+    "A T-shaped cross-section defined by depth, flange width, web thickness, and flange thickness (IfcTShapeProfileDef). " +
+    "Adjust the dimensions in the profile editor.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: T-Shape Cross-Section",
+      description:
+        "IfcTShapeProfileDef defines a tee-shaped section with a top flange and a centered web. " +
+        "This sample focuses on the main dimensional parameters used to form the profile.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector specifies where the T-shaped profile is swept. " +
+        "Use this step to inspect direction and depth before generating the final solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The T-shaped cross-section is extruded along the Z-axis to produce a 3D solid (IfcExtrudedAreaSolid).",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["t-shape"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const flangeWidth =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.flangeWidth
+        : DEFAULT_PROFILE.flangeWidth;
+    const tDepth =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.depth
+        : DEFAULT_PROFILE.depth;
+    const webThickness =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.webThickness
+        : DEFAULT_PROFILE.webThickness;
+    const flangeThickness =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.flangeThickness
+        : DEFAULT_PROFILE.flangeThickness;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcTShapeProfileDef",
+        profileType: "AREA",
+        depth: tDepth,
+        flangeWidth,
+        webThickness,
+        flangeThickness,
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, activeProfile, "tshape_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcTShapeProfileDef",
+      profileType: "AREA",
+      depth: "(see profile editor)",
+      flangeWidth: "(see profile editor)",
+      webThickness: "(see profile editor)",
+      flangeThickness: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/ifc/samples/extrusion.t-shape.ts
+++ b/src/ifc/samples/extrusion.t-shape.ts
@@ -23,6 +23,9 @@ const DEFAULT_PROFILE: IfcProfileDef = {
   flangeWidth: 4,
   webThickness: 0.8,
   flangeThickness: 1.2,
+  filletRadius: 0.2,
+  flangeEdgeRadius: 0.15,
+  webEdgeRadius: 0.15,
 };
 
 const DEFAULT_EXTRUSION: ExtrusionParams = {
@@ -41,7 +44,7 @@ export const extrusionTShapeSample: SampleDef = {
   id: "extrusion-t-shape",
   title: "T-Shape / Tee Profile (IfcTShapeProfileDef)",
   description:
-    "A T-shaped cross-section defined by depth, flange width, web thickness, and flange thickness (IfcTShapeProfileDef). " +
+    "A T-shaped cross-section defined by depth, flange width, web thickness, flange thickness, and optional edge radii (IfcTShapeProfileDef). " +
     "Adjust the dimensions in the profile editor.",
   parameters: [],
   steps: [
@@ -50,7 +53,7 @@ export const extrusionTShapeSample: SampleDef = {
       label: "Step 1: T-Shape Cross-Section",
       description:
         "IfcTShapeProfileDef defines a tee-shaped section with a top flange and a centered web. " +
-        "This sample focuses on the main dimensional parameters used to form the profile.",
+        "This sample also exposes the optional fillet, flange-edge, and web-edge radii from the profile definition.",
     },
     {
       id: "direction",
@@ -108,6 +111,18 @@ export const extrusionTShapeSample: SampleDef = {
       activeProfile.type === "IfcTShapeProfileDef"
         ? activeProfile.flangeThickness
         : DEFAULT_PROFILE.flangeThickness;
+    const filletRadius =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.filletRadius
+        : DEFAULT_PROFILE.filletRadius;
+    const flangeEdgeRadius =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.flangeEdgeRadius
+        : DEFAULT_PROFILE.flangeEdgeRadius;
+    const webEdgeRadius =
+      activeProfile.type === "IfcTShapeProfileDef"
+        ? activeProfile.webEdgeRadius
+        : DEFAULT_PROFILE.webEdgeRadius;
 
     const generatedSolid: IfcExtrudedAreaSolid = {
       type: "IfcExtrudedAreaSolid",
@@ -118,6 +133,9 @@ export const extrusionTShapeSample: SampleDef = {
         flangeWidth,
         webThickness,
         flangeThickness,
+        filletRadius,
+        flangeEdgeRadius,
+        webEdgeRadius,
       },
       position: {
         type: "IfcAxis2Placement3D",
@@ -205,6 +223,9 @@ export const extrusionTShapeSample: SampleDef = {
       flangeWidth: "(see profile editor)",
       webThickness: "(see profile editor)",
       flangeThickness: "(see profile editor)",
+      filletRadius: "(see profile editor)",
+      flangeEdgeRadius: "(see profile editor)",
+      webEdgeRadius: "(see profile editor)",
     },
     position: {
       type: "IfcAxis2Placement3D",

--- a/src/ifc/schema.ts
+++ b/src/ifc/schema.ts
@@ -31,4 +31,5 @@ export type {
   IfcEllipseProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
+  IfcTShapeProfileDef,
 } from "./generated/schema.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type {
   IfcEllipseProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
+  IfcTShapeProfileDef,
 } from "./ifc/generated/schema.ts";
 
 // ── UI model coordinate types ──────────────────────────────────────────────
@@ -168,6 +169,7 @@ export type ProfileType =
   | "c-shape"
   | "i-shape"
   | "l-shape"
+  | "t-shape"
   | "arbitrary";
 
 export interface ProfileEditorConfig {

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -8,6 +8,7 @@ import type {
   IfcCShapeProfileDef,
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
+  IfcTShapeProfileDef,
   IfcArbitraryClosedProfileDef,
   Vec2,
 } from "../types.ts";
@@ -72,6 +73,8 @@ export class ProfileEditor {
         return "i-shape";
       case "IfcLShapeProfileDef":
         return "l-shape";
+      case "IfcTShapeProfileDef":
+        return "t-shape";
       case "IfcArbitraryClosedProfileDef":
       case "IfcArbitraryProfileDefWithVoids":
         return "arbitrary";
@@ -153,6 +156,16 @@ export class ProfileEditor {
           width: 3,
           thickness: 0.4,
         } satisfies IfcLShapeProfileDef);
+        break;
+      case "t-shape":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcTShapeProfileDef",
+          profileType: "AREA",
+          depth: 5,
+          flangeWidth: 4,
+          webThickness: 0.8,
+          flangeThickness: 1.2,
+        } satisfies IfcTShapeProfileDef);
         break;
       case "arbitrary":
         this.currentProfile = this._cloneProfile({
@@ -286,6 +299,31 @@ export class ProfileEditor {
       `;
     }
 
+    if (p.type === "IfcTShapeProfileDef") {
+      const tsWebMin = 0.05;
+      const tsWebRawMax = p.flangeWidth;
+      const tsWebMax = Math.max(tsWebMin, tsWebRawMax);
+      const tsWeb = Math.min(Math.max(p.webThickness, tsWebMin), tsWebMax);
+
+      const tsFlangeMin = 0.05;
+      const tsFlangeRawMax = p.depth;
+      const tsFlangeMax = Math.max(tsFlangeMin, tsFlangeRawMax);
+      const tsFlange = Math.min(
+        Math.max(p.flangeThickness, tsFlangeMin),
+        tsFlangeMax,
+      );
+
+      p.webThickness = tsWeb;
+      p.flangeThickness = tsFlange;
+
+      return `
+        ${this._sliderHTML("ts-d", "Depth", p.depth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("ts-fw", "Flange Width", p.flangeWidth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("ts-wt", "Web Thickness", tsWeb, tsWebMin, tsWebMax, 0.05)}
+        ${this._sliderHTML("ts-ft", "Flange Thickness", tsFlange, tsFlangeMin, tsFlangeMax, 0.05)}
+      `;
+    }
+
     if (
       p.type === "IfcArbitraryClosedProfileDef" ||
       p.type === "IfcArbitraryProfileDefWithVoids"
@@ -349,6 +387,7 @@ export class ProfileEditor {
       "c-shape": "C-Shape",
       "i-shape": "I-Shape",
       "l-shape": "L-Shape",
+      "t-shape": "T-Shape",
       arbitrary: "Arbitrary",
     };
     return labels[t];
@@ -513,6 +552,26 @@ export class ProfileEditor {
     });
     this._bindSlider("ls-t", (v) => {
       (this.currentProfile as IfcLShapeProfileDef).thickness = v;
+    });
+
+    // ── T-Shape ──
+    this._bindSlider("ts-d", (v) => {
+      const prof = this.currentProfile as IfcTShapeProfileDef;
+      prof.depth = v;
+      const max = Math.max(0.05, prof.depth);
+      prof.flangeThickness = this._clampDependentSlider("ts-ft", max);
+    });
+    this._bindSlider("ts-fw", (v) => {
+      const prof = this.currentProfile as IfcTShapeProfileDef;
+      prof.flangeWidth = v;
+      const max = Math.max(0.05, prof.flangeWidth);
+      prof.webThickness = this._clampDependentSlider("ts-wt", max);
+    });
+    this._bindSlider("ts-wt", (v) => {
+      (this.currentProfile as IfcTShapeProfileDef).webThickness = v;
+    });
+    this._bindSlider("ts-ft", (v) => {
+      (this.currentProfile as IfcTShapeProfileDef).flangeThickness = v;
     });
 
     // ── Arbitrary point inputs ──

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -165,6 +165,9 @@ export class ProfileEditor {
           flangeWidth: 4,
           webThickness: 0.8,
           flangeThickness: 1.2,
+          filletRadius: 0.2,
+          flangeEdgeRadius: 0.15,
+          webEdgeRadius: 0.15,
         } satisfies IfcTShapeProfileDef);
         break;
       case "arbitrary":
@@ -315,12 +318,35 @@ export class ProfileEditor {
 
       p.webThickness = tsWeb;
       p.flangeThickness = tsFlange;
+      const tsFilletMax = this._maxTShapeFilletRadius();
+      const tsFillet = Math.min(
+        Math.max(p.filletRadius ?? 0, 0),
+        tsFilletMax,
+      );
+      p.filletRadius = tsFillet;
+
+      const tsFlangeEdgeMax = this._maxTShapeFlangeEdgeRadius();
+      const tsFlangeEdge = Math.min(
+        Math.max(p.flangeEdgeRadius ?? 0, 0),
+        tsFlangeEdgeMax,
+      );
+      p.flangeEdgeRadius = tsFlangeEdge;
+
+      const tsWebEdgeMax = this._maxTShapeWebEdgeRadius();
+      const tsWebEdge = Math.min(
+        Math.max(p.webEdgeRadius ?? 0, 0),
+        tsWebEdgeMax,
+      );
+      p.webEdgeRadius = tsWebEdge;
 
       return `
         ${this._sliderHTML("ts-d", "Depth", p.depth, 0.5, 10, 0.1)}
         ${this._sliderHTML("ts-fw", "Flange Width", p.flangeWidth, 0.5, 10, 0.1)}
         ${this._sliderHTML("ts-wt", "Web Thickness", tsWeb, tsWebMin, tsWebMax, 0.05)}
         ${this._sliderHTML("ts-ft", "Flange Thickness", tsFlange, tsFlangeMin, tsFlangeMax, 0.05)}
+        ${this._sliderHTML("ts-fr", "Fillet Radius", tsFillet, 0, tsFilletMax, 0.05)}
+        ${this._sliderHTML("ts-fer", "Flange Edge Radius", tsFlangeEdge, 0, tsFlangeEdgeMax, 0.05)}
+        ${this._sliderHTML("ts-wer", "Web Edge Radius", tsWebEdge, 0, tsWebEdgeMax, 0.05)}
       `;
     }
 
@@ -560,18 +586,44 @@ export class ProfileEditor {
       prof.depth = v;
       const max = Math.max(0.05, prof.depth);
       prof.flangeThickness = this._clampDependentSlider("ts-ft", max);
+      prof.filletRadius = this._clampTShapeFilletRadius();
+      prof.flangeEdgeRadius = this._clampTShapeFlangeEdgeRadius();
+      prof.webEdgeRadius = this._clampTShapeWebEdgeRadius();
     });
     this._bindSlider("ts-fw", (v) => {
       const prof = this.currentProfile as IfcTShapeProfileDef;
       prof.flangeWidth = v;
       const max = Math.max(0.05, prof.flangeWidth);
       prof.webThickness = this._clampDependentSlider("ts-wt", max);
+      prof.filletRadius = this._clampTShapeFilletRadius();
+      prof.flangeEdgeRadius = this._clampTShapeFlangeEdgeRadius();
     });
     this._bindSlider("ts-wt", (v) => {
-      (this.currentProfile as IfcTShapeProfileDef).webThickness = v;
+      const prof = this.currentProfile as IfcTShapeProfileDef;
+      prof.webThickness = v;
+      prof.filletRadius = this._clampTShapeFilletRadius();
+      prof.flangeEdgeRadius = this._clampTShapeFlangeEdgeRadius();
+      prof.webEdgeRadius = this._clampTShapeWebEdgeRadius();
     });
     this._bindSlider("ts-ft", (v) => {
-      (this.currentProfile as IfcTShapeProfileDef).flangeThickness = v;
+      const prof = this.currentProfile as IfcTShapeProfileDef;
+      prof.flangeThickness = v;
+      prof.filletRadius = this._clampTShapeFilletRadius();
+      prof.flangeEdgeRadius = this._clampTShapeFlangeEdgeRadius();
+      prof.webEdgeRadius = this._clampTShapeWebEdgeRadius();
+    });
+    this._bindSlider("ts-fr", (v) => {
+      (this.currentProfile as IfcTShapeProfileDef).filletRadius = v;
+      (this.currentProfile as IfcTShapeProfileDef).flangeEdgeRadius =
+        this._clampTShapeFlangeEdgeRadius();
+      (this.currentProfile as IfcTShapeProfileDef).webEdgeRadius =
+        this._clampTShapeWebEdgeRadius();
+    });
+    this._bindSlider("ts-fer", (v) => {
+      (this.currentProfile as IfcTShapeProfileDef).flangeEdgeRadius = v;
+    });
+    this._bindSlider("ts-wer", (v) => {
+      (this.currentProfile as IfcTShapeProfileDef).webEdgeRadius = v;
     });
 
     // ── Arbitrary point inputs ──
@@ -668,5 +720,62 @@ export class ProfileEditor {
       ),
     );
     return this._clampDependentSlider("cs-r", max);
+  }
+
+  private _maxTShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcTShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    return Math.max(
+      0,
+      Math.min(
+        prof.flangeWidth / 2 - prof.webThickness / 2,
+        prof.flangeThickness,
+        prof.depth - prof.flangeThickness,
+      ),
+    );
+  }
+
+  private _maxTShapeFlangeEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcTShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const filletRadius = prof.filletRadius ?? 0;
+    return Math.max(
+      0,
+      Math.min(
+        prof.flangeThickness,
+        prof.flangeWidth / 2 - prof.webThickness / 2 - filletRadius,
+      ),
+    );
+  }
+
+  private _maxTShapeWebEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcTShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const filletRadius = prof.filletRadius ?? 0;
+    return Math.max(
+      0,
+      Math.min(
+        prof.webThickness / 2,
+        prof.depth - prof.flangeThickness - filletRadius,
+      ),
+    );
+  }
+
+  private _clampTShapeFilletRadius(): number {
+    return this._clampDependentSlider("ts-fr", this._maxTShapeFilletRadius());
+  }
+
+  private _clampTShapeFlangeEdgeRadius(): number {
+    return this._clampDependentSlider(
+      "ts-fer",
+      this._maxTShapeFlangeEdgeRadius(),
+    );
+  }
+
+  private _clampTShapeWebEdgeRadius(): number {
+    return this._clampDependentSlider(
+      "ts-wer",
+      this._maxTShapeWebEdgeRadius(),
+    );
   }
 }

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -597,6 +597,7 @@ export class ProfileEditor {
       prof.webThickness = this._clampDependentSlider("ts-wt", max);
       prof.filletRadius = this._clampTShapeFilletRadius();
       prof.flangeEdgeRadius = this._clampTShapeFlangeEdgeRadius();
+      prof.webEdgeRadius = this._clampTShapeWebEdgeRadius();
     });
     this._bindSlider("ts-wt", (v) => {
       const prof = this.currentProfile as IfcTShapeProfileDef;


### PR DESCRIPTION
## What changed
- added `IfcTShapeProfileDef` support to the extrusion normalization and profile outline paths used by `IfcExtrudedAreaSolid`
- added a dedicated T-shape extrusion sample and registered it in the app routes
- extended the profile editor with T-shape controls, including `filletRadius`, `flangeEdgeRadius`, and `webEdgeRadius`

## Why
`IfcTShapeProfileDef` was not available in the playground, so extruded tee sections could not be explored or compared against the `web-ifc` reference behavior. The follow-up also wires the optional radius parameters that `web-ifc` already supports.

## Impact
- users can inspect and edit T-shape extrusions in the playground
- the generated IFC representation now includes the optional T-shape radius fields
- the editor clamps dependent radius values so invalid geometry combinations are avoided

## Validation
- `bun run build`
