### PR TITLE
[codex] Add IfcUShapeProfileDef extrusion support

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -11,6 +11,7 @@ import { extrusionCShapeSample } from "../ifc/samples/extrusion.c-shape.ts";
 import { extrusionIShapeSample } from "../ifc/samples/extrusion.i-shape.ts";
 import { extrusionLShapeSample } from "../ifc/samples/extrusion.l-shape.ts";
 import { extrusionTShapeSample } from "../ifc/samples/extrusion.t-shape.ts";
+import { extrusionUShapeSample } from "../ifc/samples/extrusion.u-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import type { SampleDef } from "../types.ts";
 
@@ -25,6 +26,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-i-shape": extrusionIShapeSample,
   "extrusion-l-shape": extrusionLShapeSample,
   "extrusion-t-shape": extrusionTShapeSample,
+  "extrusion-u-shape": extrusionUShapeSample,
   "swept-disk-basic": sweptDiskBasicSample,
 };
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -181,6 +181,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-u-shape",
+    title: "U-Shape Profile (IfcUShapeProfileDef)",
+    description:
+      "Extrudes a U-shaped cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcUShapeProfileDef).",
+    sampleId: "extrusion-u-shape",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/tessellation",
     title: "Triangulated Face Set",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -486,15 +486,26 @@ function uShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'If
   const yBottom = -hd
   const yFlangeTop = hd - profile.flangeThickness
   const yFlangeBottom = -hd + profile.flangeThickness
-  const rInner = Math.min(
-    profile.filletRadius ?? 0,
-    Math.max(0, hw - xWeb),
-    Math.max(0, profile.flangeThickness),
+  const horizontalRadiusBudget = Math.max(0, profile.flangeWidth - profile.webThickness)
+  const innerVerticalBudget = Math.max(0, profile.depth / 2 - profile.flangeThickness)
+  const edgeVerticalBudget = Math.max(0, profile.flangeThickness)
+  const rawInner = Math.max(0, profile.filletRadius ?? 0)
+  const rawEdge = Math.max(0, profile.edgeRadius ?? 0)
+
+  let rEdge = Math.min(
+    rawEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rawInner),
   )
-  const rEdge = Math.min(
-    profile.edgeRadius ?? 0,
-    Math.max(0, profile.flangeThickness - rInner),
-    Math.max(0, profile.flangeWidth / 2),
+  const rInner = Math.min(
+    rawInner,
+    innerVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rEdge),
+  )
+  rEdge = Math.min(
+    rEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rInner),
   )
 
   if (rInner <= 1e-6 && rEdge <= 1e-6) {

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -478,6 +478,98 @@ function tShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'If
   return ensureCounterClockwise(pts)
 }
 
+function uShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'IfcUShapeProfileDef' }>): NormalizedVec2[] {
+  const hd = profile.depth / 2
+  const hw = profile.flangeWidth / 2
+  const xWeb = -hw + profile.webThickness
+  const yTop = hd
+  const yBottom = -hd
+  const yFlangeTop = hd - profile.flangeThickness
+  const yFlangeBottom = -hd + profile.flangeThickness
+  const rInner = Math.min(
+    profile.filletRadius ?? 0,
+    Math.max(0, hw - xWeb),
+    Math.max(0, profile.flangeThickness),
+  )
+  const rEdge = Math.min(
+    profile.edgeRadius ?? 0,
+    Math.max(0, profile.flangeThickness - rInner),
+    Math.max(0, profile.flangeWidth / 2),
+  )
+
+  if (rInner <= 1e-6 && rEdge <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: yTop },
+      { x: hw, y: yTop },
+      { x: hw, y: yFlangeTop },
+      { x: xWeb, y: yFlangeTop },
+      { x: xWeb, y: yFlangeBottom },
+      { x: hw, y: yFlangeBottom },
+      { x: hw, y: yBottom },
+      { x: -hw, y: yBottom },
+    ])
+  }
+
+  const pts: NormalizedVec2[] = [
+    { x: -hw, y: yTop },
+    { x: hw, y: yTop },
+  ]
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw, y: yFlangeTop + rEdge })
+    appendArc(pts, hw - rEdge, yFlangeTop + rEdge, rEdge, 0, -Math.PI / 2)
+  } else {
+    pts.push({ x: hw, y: yFlangeTop })
+  }
+
+  if (rInner > 1e-6) {
+    pts.push({ x: xWeb + rInner, y: yFlangeTop })
+    appendArc(
+      pts,
+      xWeb + rInner,
+      yFlangeTop - rInner,
+      rInner,
+      Math.PI / 2,
+      Math.PI,
+    )
+    pts.push({ x: xWeb, y: yFlangeBottom + rInner })
+    appendArc(
+      pts,
+      xWeb + rInner,
+      yFlangeBottom + rInner,
+      rInner,
+      Math.PI,
+      (3 * Math.PI) / 2,
+    )
+  } else {
+    pts.push(
+      { x: xWeb, y: yFlangeTop },
+      { x: xWeb, y: yFlangeBottom },
+    )
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw - rEdge, y: yFlangeBottom })
+    appendArc(
+      pts,
+      hw - rEdge,
+      yFlangeBottom - rEdge,
+      rEdge,
+      Math.PI / 2,
+      0,
+    )
+  } else {
+    pts.push({ x: hw, y: yFlangeBottom })
+  }
+
+  pts.push(
+    { x: hw, y: yBottom },
+    { x: -hw, y: yBottom },
+  )
+
+  return ensureCounterClockwise(pts)
+}
+
 /**
  * Apply a 2D placement transform to a list of profile-space points.
  * The Y axis is the 90° CCW rotation of the X axis.
@@ -501,7 +593,7 @@ function applyPlacement2DToLoop(
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
  * Supported types: Rectangle, Circle, Ellipse, RectangleHollow,
- * CircleHollow, IShape (symmetric), TShape, LShape, CShape.
+ * CircleHollow, IShape (symmetric), TShape, UShape, LShape, CShape.
  * Other parameterized types throw an Error.
  */
 export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): NormalizedProfile {
@@ -581,6 +673,10 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
 
     case 'IfcTShapeProfileDef':
       outerLoop = tShapeLoop(profile)
+      break
+
+    case 'IfcUShapeProfileDef':
+      outerLoop = uShapeLoop(profile)
       break
 
     case 'IfcLShapeProfileDef': {

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -13,6 +13,7 @@ import type {
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
+  IfcUShapeProfileDef,
   Vec2,
 } from "../../types.ts";
 import {
@@ -351,6 +352,98 @@ function tShapeVec2(p: IfcTShapeProfileDef): Vec2[] {
   return ensureCounterClockwise(pts);
 }
 
+function uShapeVec2(p: IfcUShapeProfileDef): Vec2[] {
+  const hd = p.depth / 2;
+  const hw = p.flangeWidth / 2;
+  const xWeb = -hw + p.webThickness;
+  const yTop = hd;
+  const yBottom = -hd;
+  const yFlangeTop = hd - p.flangeThickness;
+  const yFlangeBottom = -hd + p.flangeThickness;
+  const rInner = Math.min(
+    p.filletRadius ?? 0,
+    Math.max(0, hw - xWeb),
+    Math.max(0, p.flangeThickness),
+  );
+  const rEdge = Math.min(
+    p.edgeRadius ?? 0,
+    Math.max(0, p.flangeThickness - rInner),
+    Math.max(0, p.flangeWidth / 2),
+  );
+
+  if (rInner <= 1e-6 && rEdge <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: yTop },
+      { x: hw, y: yTop },
+      { x: hw, y: yFlangeTop },
+      { x: xWeb, y: yFlangeTop },
+      { x: xWeb, y: yFlangeBottom },
+      { x: hw, y: yFlangeBottom },
+      { x: hw, y: yBottom },
+      { x: -hw, y: yBottom },
+    ]);
+  }
+
+  const pts: Vec2[] = [
+    { x: -hw, y: yTop },
+    { x: hw, y: yTop },
+  ];
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw, y: yFlangeTop + rEdge });
+    appendArc(pts, hw - rEdge, yFlangeTop + rEdge, rEdge, 0, -Math.PI / 2);
+  } else {
+    pts.push({ x: hw, y: yFlangeTop });
+  }
+
+  if (rInner > 1e-6) {
+    pts.push({ x: xWeb + rInner, y: yFlangeTop });
+    appendArc(
+      pts,
+      xWeb + rInner,
+      yFlangeTop - rInner,
+      rInner,
+      Math.PI / 2,
+      Math.PI,
+    );
+    pts.push({ x: xWeb, y: yFlangeBottom + rInner });
+    appendArc(
+      pts,
+      xWeb + rInner,
+      yFlangeBottom + rInner,
+      rInner,
+      Math.PI,
+      (3 * Math.PI) / 2,
+    );
+  } else {
+    pts.push(
+      { x: xWeb, y: yFlangeTop },
+      { x: xWeb, y: yFlangeBottom },
+    );
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw - rEdge, y: yFlangeBottom });
+    appendArc(
+      pts,
+      hw - rEdge,
+      yFlangeBottom - rEdge,
+      rEdge,
+      Math.PI / 2,
+      0,
+    );
+  } else {
+    pts.push({ x: hw, y: yFlangeBottom });
+  }
+
+  pts.push(
+    { x: hw, y: yBottom },
+    { x: -hw, y: yBottom },
+  );
+
+  return ensureCounterClockwise(pts);
+}
+
 // ── Public polygon accessors ───────────────────────────────────────────────
 
 /** Outer boundary of any profile as Vec2 list. */
@@ -390,6 +483,8 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
       return lShapeVec2(profile);
     case "IfcTShapeProfileDef":
       return tShapeVec2(profile);
+    case "IfcUShapeProfileDef":
+      return uShapeVec2(profile);
     case "IfcArbitraryClosedProfileDef":
     case "IfcArbitraryProfileDefWithVoids":
       return profile.outerCurve;

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -360,15 +360,26 @@ function uShapeVec2(p: IfcUShapeProfileDef): Vec2[] {
   const yBottom = -hd;
   const yFlangeTop = hd - p.flangeThickness;
   const yFlangeBottom = -hd + p.flangeThickness;
-  const rInner = Math.min(
-    p.filletRadius ?? 0,
-    Math.max(0, hw - xWeb),
-    Math.max(0, p.flangeThickness),
+  const horizontalRadiusBudget = Math.max(0, p.flangeWidth - p.webThickness);
+  const innerVerticalBudget = Math.max(0, p.depth / 2 - p.flangeThickness);
+  const edgeVerticalBudget = Math.max(0, p.flangeThickness);
+  const rawInner = Math.max(0, p.filletRadius ?? 0);
+  const rawEdge = Math.max(0, p.edgeRadius ?? 0);
+
+  let rEdge = Math.min(
+    rawEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rawInner),
   );
-  const rEdge = Math.min(
-    p.edgeRadius ?? 0,
-    Math.max(0, p.flangeThickness - rInner),
-    Math.max(0, p.flangeWidth / 2),
+  const rInner = Math.min(
+    rawInner,
+    innerVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rEdge),
+  );
+  rEdge = Math.min(
+    rEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rInner),
   );
 
   if (rInner <= 1e-6 && rEdge <= 1e-6) {

--- a/src/ifc/samples/extrusion.u-shape.ts
+++ b/src/ifc/samples/extrusion.u-shape.ts
@@ -51,7 +51,7 @@ export const extrusionUShapeSample: SampleDef = {
       id: "profile",
       label: "Step 1: U-Shape Cross-Section",
       description:
-        "IfcUShapeProfileDef defines a channel-like section with a left web and top/bottom flanges opening to the left. " +
+        "IfcUShapeProfileDef defines a channel-like section with a left web and top/bottom flanges opening to the right. " +
         "This sample exposes the optional inner fillet radius and outer edge radius used by the profile.",
     },
     {

--- a/src/ifc/samples/extrusion.u-shape.ts
+++ b/src/ifc/samples/extrusion.u-shape.ts
@@ -1,0 +1,235 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcUShapeProfileDef",
+  profileType: "AREA",
+  depth: 5,
+  flangeWidth: 4,
+  webThickness: 0.6,
+  flangeThickness: 0.8,
+  filletRadius: 0.2,
+  edgeRadius: 0.15,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 6,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionUShapeSample: SampleDef = {
+  id: "extrusion-u-shape",
+  title: "U-Shape / Channel Profile (IfcUShapeProfileDef)",
+  description:
+    "A U-shaped cross-section defined by depth, flange width, web thickness, flange thickness, and optional corner radii (IfcUShapeProfileDef). " +
+    "Adjust the dimensions in the profile editor.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: U-Shape Cross-Section",
+      description:
+        "IfcUShapeProfileDef defines a channel-like section with a left web and top/bottom flanges opening to the left. " +
+        "This sample exposes the optional inner fillet radius and outer edge radius used by the profile.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector specifies where the U-shaped profile is swept. " +
+        "Use this step to inspect direction and depth before generating the final solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The U-shaped cross-section is extruded along the Z-axis to produce a 3D solid (IfcExtrudedAreaSolid).",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["u-shape"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const uDepth =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.depth
+        : DEFAULT_PROFILE.depth;
+    const flangeWidth =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.flangeWidth
+        : DEFAULT_PROFILE.flangeWidth;
+    const webThickness =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.webThickness
+        : DEFAULT_PROFILE.webThickness;
+    const flangeThickness =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.flangeThickness
+        : DEFAULT_PROFILE.flangeThickness;
+    const filletRadius =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.filletRadius
+        : DEFAULT_PROFILE.filletRadius;
+    const edgeRadius =
+      activeProfile.type === "IfcUShapeProfileDef"
+        ? activeProfile.edgeRadius
+        : DEFAULT_PROFILE.edgeRadius;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcUShapeProfileDef",
+        profileType: "AREA",
+        depth: uDepth,
+        flangeWidth,
+        webThickness,
+        flangeThickness,
+        ...(filletRadius && filletRadius > 0 ? { filletRadius } : {}),
+        ...(edgeRadius && edgeRadius > 0 ? { edgeRadius } : {}),
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, activeProfile, "ushape_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcUShapeProfileDef",
+      profileType: "AREA",
+      depth: "(see profile editor)",
+      flangeWidth: "(see profile editor)",
+      webThickness: "(see profile editor)",
+      flangeThickness: "(see profile editor)",
+      filletRadius: "(see profile editor)",
+      edgeRadius: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/ifc/schema.ts
+++ b/src/ifc/schema.ts
@@ -32,4 +32,5 @@ export type {
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
+  IfcUShapeProfileDef,
 } from "./generated/schema.ts";

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type {
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
+  IfcUShapeProfileDef,
 } from "./ifc/generated/schema.ts";
 
 // ── UI model coordinate types ──────────────────────────────────────────────
@@ -170,6 +171,7 @@ export type ProfileType =
   | "i-shape"
   | "l-shape"
   | "t-shape"
+  | "u-shape"
   | "arbitrary";
 
 export interface ProfileEditorConfig {

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -382,6 +382,10 @@ export class ProfileEditor {
       p.webThickness = usWeb;
       p.flangeThickness = usFlange;
 
+      p.edgeRadius = this._normalizeUShapeEdgeRadius();
+      p.filletRadius = this._normalizeUShapeFilletRadius();
+      p.edgeRadius = this._normalizeUShapeEdgeRadius();
+
       const usFilletMax = this._maxUShapeFilletRadius();
       const usFillet = Math.min(
         Math.max(p.filletRadius ?? 0, 0),
@@ -698,16 +702,21 @@ export class ProfileEditor {
       prof.flangeWidth = v;
       const webMax = Math.max(0.05, prof.flangeWidth - 0.05);
       prof.webThickness = this._clampDependentSlider("us-wt", webMax);
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
       prof.filletRadius = this._clampUShapeFilletRadius();
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
     });
     this._bindSlider("us-wt", (v) => {
       const prof = this.currentProfile as IfcUShapeProfileDef;
       prof.webThickness = v;
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
       prof.filletRadius = this._clampUShapeFilletRadius();
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
     });
     this._bindSlider("us-ft", (v) => {
       const prof = this.currentProfile as IfcUShapeProfileDef;
       prof.flangeThickness = v;
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
       prof.filletRadius = this._clampUShapeFilletRadius();
       prof.edgeRadius = this._clampUShapeEdgeRadius();
     });
@@ -718,6 +727,8 @@ export class ProfileEditor {
     });
     this._bindSlider("us-er", (v) => {
       (this.currentProfile as IfcUShapeProfileDef).edgeRadius = v;
+      (this.currentProfile as IfcUShapeProfileDef).filletRadius =
+        this._clampUShapeFilletRadius();
     });
 
     // ── Arbitrary point inputs ──
@@ -876,11 +887,12 @@ export class ProfileEditor {
   private _maxUShapeFilletRadius(): number {
     if (this.currentProfile.type !== "IfcUShapeProfileDef") return 0;
     const prof = this.currentProfile;
+    const edgeRadius = prof.edgeRadius ?? 0;
     return Math.max(
       0,
       Math.min(
-        prof.webThickness,
-        prof.flangeThickness,
+        prof.flangeWidth - prof.webThickness - edgeRadius,
+        prof.depth / 2 - prof.flangeThickness,
       ),
     );
   }
@@ -892,10 +904,32 @@ export class ProfileEditor {
     return Math.max(
       0,
       Math.min(
-        prof.flangeThickness - filletRadius,
-        prof.flangeWidth / 2,
+        prof.flangeThickness,
+        prof.flangeWidth - prof.webThickness - filletRadius,
       ),
     );
+  }
+
+  private _normalizeUShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcUShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const next = Math.min(
+      Math.max(prof.filletRadius ?? 0, 0),
+      this._maxUShapeFilletRadius(),
+    );
+    prof.filletRadius = next;
+    return next;
+  }
+
+  private _normalizeUShapeEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcUShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const next = Math.min(
+      Math.max(prof.edgeRadius ?? 0, 0),
+      this._maxUShapeEdgeRadius(),
+    );
+    prof.edgeRadius = next;
+    return next;
   }
 
   private _clampUShapeFilletRadius(): number {

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -387,18 +387,9 @@ export class ProfileEditor {
       p.edgeRadius = this._normalizeUShapeEdgeRadius();
 
       const usFilletMax = this._maxUShapeFilletRadius();
-      const usFillet = Math.min(
-        Math.max(p.filletRadius ?? 0, 0),
-        usFilletMax,
-      );
-      p.filletRadius = usFillet;
-
       const usEdgeMax = this._maxUShapeEdgeRadius();
-      const usEdge = Math.min(
-        Math.max(p.edgeRadius ?? 0, 0),
-        usEdgeMax,
-      );
-      p.edgeRadius = usEdge;
+      const usFillet = p.filletRadius ?? 0;
+      const usEdge = p.edgeRadius ?? 0;
 
       return `
         ${this._sliderHTML("us-d", "Depth", p.depth, 0.5, 10, 0.1)}
@@ -694,31 +685,22 @@ export class ProfileEditor {
       prof.depth = v;
       const flangeMax = Math.max(0.05, prof.depth / 2 - 0.05);
       prof.flangeThickness = this._clampDependentSlider("us-ft", flangeMax);
-      prof.filletRadius = this._clampUShapeFilletRadius();
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
+      this._syncUShapeRadii();
     });
     this._bindSlider("us-fw", (v) => {
       const prof = this.currentProfile as IfcUShapeProfileDef;
       prof.flangeWidth = v;
       const webMax = Math.max(0.05, prof.flangeWidth - 0.05);
       prof.webThickness = this._clampDependentSlider("us-wt", webMax);
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
-      prof.filletRadius = this._clampUShapeFilletRadius();
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
+      this._syncUShapeRadii();
     });
     this._bindSlider("us-wt", (v) => {
-      const prof = this.currentProfile as IfcUShapeProfileDef;
-      prof.webThickness = v;
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
-      prof.filletRadius = this._clampUShapeFilletRadius();
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
+      (this.currentProfile as IfcUShapeProfileDef).webThickness = v;
+      this._syncUShapeRadii();
     });
     this._bindSlider("us-ft", (v) => {
-      const prof = this.currentProfile as IfcUShapeProfileDef;
-      prof.flangeThickness = v;
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
-      prof.filletRadius = this._clampUShapeFilletRadius();
-      prof.edgeRadius = this._clampUShapeEdgeRadius();
+      (this.currentProfile as IfcUShapeProfileDef).flangeThickness = v;
+      this._syncUShapeRadii();
     });
     this._bindSlider("us-fr", (v) => {
       (this.currentProfile as IfcUShapeProfileDef).filletRadius = v;
@@ -930,6 +912,16 @@ export class ProfileEditor {
     );
     prof.edgeRadius = next;
     return next;
+  }
+
+  private _syncUShapeRadii(): void {
+    const prof = this.currentProfile as IfcUShapeProfileDef;
+    // edgeRadius and filletRadius are mutually dependent, so we clamp edge
+    // first, then fillet (which may tighten edgeMax), then edge again to
+    // ensure both constraints are satisfied simultaneously.
+    prof.edgeRadius = this._clampUShapeEdgeRadius();
+    prof.filletRadius = this._clampUShapeFilletRadius();
+    prof.edgeRadius = this._clampUShapeEdgeRadius();
   }
 
   private _clampUShapeFilletRadius(): number {

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -9,6 +9,7 @@ import type {
   IfcIShapeProfileDef,
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
+  IfcUShapeProfileDef,
   IfcArbitraryClosedProfileDef,
   Vec2,
 } from "../types.ts";
@@ -75,6 +76,8 @@ export class ProfileEditor {
         return "l-shape";
       case "IfcTShapeProfileDef":
         return "t-shape";
+      case "IfcUShapeProfileDef":
+        return "u-shape";
       case "IfcArbitraryClosedProfileDef":
       case "IfcArbitraryProfileDefWithVoids":
         return "arbitrary";
@@ -169,6 +172,18 @@ export class ProfileEditor {
           flangeEdgeRadius: 0.15,
           webEdgeRadius: 0.15,
         } satisfies IfcTShapeProfileDef);
+        break;
+      case "u-shape":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcUShapeProfileDef",
+          profileType: "AREA",
+          depth: 5,
+          flangeWidth: 4,
+          webThickness: 0.6,
+          flangeThickness: 0.8,
+          filletRadius: 0.2,
+          edgeRadius: 0.15,
+        } satisfies IfcUShapeProfileDef);
         break;
       case "arbitrary":
         this.currentProfile = this._cloneProfile({
@@ -350,6 +365,47 @@ export class ProfileEditor {
       `;
     }
 
+    if (p.type === "IfcUShapeProfileDef") {
+      const usWebMin = 0.05;
+      const usWebRawMax = p.flangeWidth - usWebMin;
+      const usWebMax = Math.max(usWebMin, usWebRawMax);
+      const usWeb = Math.min(Math.max(p.webThickness, usWebMin), usWebMax);
+
+      const usFlangeMin = 0.05;
+      const usFlangeRawMax = p.depth / 2 - usFlangeMin;
+      const usFlangeMax = Math.max(usFlangeMin, usFlangeRawMax);
+      const usFlange = Math.min(
+        Math.max(p.flangeThickness, usFlangeMin),
+        usFlangeMax,
+      );
+
+      p.webThickness = usWeb;
+      p.flangeThickness = usFlange;
+
+      const usFilletMax = this._maxUShapeFilletRadius();
+      const usFillet = Math.min(
+        Math.max(p.filletRadius ?? 0, 0),
+        usFilletMax,
+      );
+      p.filletRadius = usFillet;
+
+      const usEdgeMax = this._maxUShapeEdgeRadius();
+      const usEdge = Math.min(
+        Math.max(p.edgeRadius ?? 0, 0),
+        usEdgeMax,
+      );
+      p.edgeRadius = usEdge;
+
+      return `
+        ${this._sliderHTML("us-d", "Depth", p.depth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("us-fw", "Flange Width", p.flangeWidth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("us-wt", "Web Thickness", usWeb, usWebMin, usWebMax, 0.05)}
+        ${this._sliderHTML("us-ft", "Flange Thickness", usFlange, usFlangeMin, usFlangeMax, 0.05)}
+        ${this._sliderHTML("us-fr", "Fillet Radius", usFillet, 0, usFilletMax, 0.05)}
+        ${this._sliderHTML("us-er", "Edge Radius", usEdge, 0, usEdgeMax, 0.05)}
+      `;
+    }
+
     if (
       p.type === "IfcArbitraryClosedProfileDef" ||
       p.type === "IfcArbitraryProfileDefWithVoids"
@@ -414,6 +470,7 @@ export class ProfileEditor {
       "i-shape": "I-Shape",
       "l-shape": "L-Shape",
       "t-shape": "T-Shape",
+      "u-shape": "U-Shape",
       arbitrary: "Arbitrary",
     };
     return labels[t];
@@ -627,6 +684,42 @@ export class ProfileEditor {
       (this.currentProfile as IfcTShapeProfileDef).webEdgeRadius = v;
     });
 
+    // ── U-Shape ──
+    this._bindSlider("us-d", (v) => {
+      const prof = this.currentProfile as IfcUShapeProfileDef;
+      prof.depth = v;
+      const flangeMax = Math.max(0.05, prof.depth / 2 - 0.05);
+      prof.flangeThickness = this._clampDependentSlider("us-ft", flangeMax);
+      prof.filletRadius = this._clampUShapeFilletRadius();
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
+    });
+    this._bindSlider("us-fw", (v) => {
+      const prof = this.currentProfile as IfcUShapeProfileDef;
+      prof.flangeWidth = v;
+      const webMax = Math.max(0.05, prof.flangeWidth - 0.05);
+      prof.webThickness = this._clampDependentSlider("us-wt", webMax);
+      prof.filletRadius = this._clampUShapeFilletRadius();
+    });
+    this._bindSlider("us-wt", (v) => {
+      const prof = this.currentProfile as IfcUShapeProfileDef;
+      prof.webThickness = v;
+      prof.filletRadius = this._clampUShapeFilletRadius();
+    });
+    this._bindSlider("us-ft", (v) => {
+      const prof = this.currentProfile as IfcUShapeProfileDef;
+      prof.flangeThickness = v;
+      prof.filletRadius = this._clampUShapeFilletRadius();
+      prof.edgeRadius = this._clampUShapeEdgeRadius();
+    });
+    this._bindSlider("us-fr", (v) => {
+      (this.currentProfile as IfcUShapeProfileDef).filletRadius = v;
+      (this.currentProfile as IfcUShapeProfileDef).edgeRadius =
+        this._clampUShapeEdgeRadius();
+    });
+    this._bindSlider("us-er", (v) => {
+      (this.currentProfile as IfcUShapeProfileDef).edgeRadius = v;
+    });
+
     // ── Arbitrary point inputs ──
     for (const input of this.container.querySelectorAll<HTMLInputElement>(
       ".point-x-input, .point-y-input",
@@ -778,5 +871,38 @@ export class ProfileEditor {
       "ts-wer",
       this._maxTShapeWebEdgeRadius(),
     );
+  }
+
+  private _maxUShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcUShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    return Math.max(
+      0,
+      Math.min(
+        prof.webThickness,
+        prof.flangeThickness,
+      ),
+    );
+  }
+
+  private _maxUShapeEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcUShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const filletRadius = prof.filletRadius ?? 0;
+    return Math.max(
+      0,
+      Math.min(
+        prof.flangeThickness - filletRadius,
+        prof.flangeWidth / 2,
+      ),
+    );
+  }
+
+  private _clampUShapeFilletRadius(): number {
+    return this._clampDependentSlider("us-fr", this._maxUShapeFilletRadius());
+  }
+
+  private _clampUShapeEdgeRadius(): number {
+    return this._clampDependentSlider("us-er", this._maxUShapeEdgeRadius());
   }
 }


### PR DESCRIPTION
## Summary
Adds `IfcUShapeProfileDef` support for `IfcExtrudedAreaSolid` across the playground so U-shaped/channel profiles can be edited, previewed, normalized, and extruded like the existing parameterized profiles.

## What changed
- added U-shape profile geometry generation in the extrusion pipeline and normalization layer
- added a dedicated U-shape sample route and sample definition
- exposed U-shape controls in `ProfileEditor` and registered the new profile type exports
- clamped `filletRadius` and `edgeRadius` together so invalid radius combinations are normalized before mesh generation

## Why
The playground already supports several parameterized extrusion profiles, but it could not demonstrate or validate U-shape/channel sections. This fills that gap and also guards against invalid radius combinations that would otherwise produce broken corners.

## Impact
Users can now open a U-shape extrusion example, tweak its dimensions interactively, and generate the corresponding solid while staying within valid radius constraints.

## Validation
- `bun run build`
