### PR TITLE
[codex] Add IfcZShapeProfileDef extrusion support

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -12,6 +12,7 @@ import { extrusionIShapeSample } from "../ifc/samples/extrusion.i-shape.ts";
 import { extrusionLShapeSample } from "../ifc/samples/extrusion.l-shape.ts";
 import { extrusionTShapeSample } from "../ifc/samples/extrusion.t-shape.ts";
 import { extrusionUShapeSample } from "../ifc/samples/extrusion.u-shape.ts";
+import { extrusionZShapeSample } from "../ifc/samples/extrusion.z-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import type { SampleDef } from "../types.ts";
 
@@ -27,6 +28,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-l-shape": extrusionLShapeSample,
   "extrusion-t-shape": extrusionTShapeSample,
   "extrusion-u-shape": extrusionUShapeSample,
+  "extrusion-z-shape": extrusionZShapeSample,
   "swept-disk-basic": sweptDiskBasicSample,
 };
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -191,6 +191,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-z-shape",
+    title: "Z-Shape Profile (IfcZShapeProfileDef)",
+    description:
+      "Extrudes a Z-shaped cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcZShapeProfileDef).",
+    sampleId: "extrusion-z-shape",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/tessellation",
     title: "Triangulated Face Set",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -478,6 +478,118 @@ function tShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'If
   return ensureCounterClockwise(pts)
 }
 
+function zShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'IfcZShapeProfileDef' }>): NormalizedVec2[] {
+  const hd = profile.depth / 2
+  const hweb = profile.webThickness / 2
+  const hw = profile.flangeWidth - hweb
+  const yTop = hd
+  const yBottom = -hd
+  const yBottomFlangeTop = -hd + profile.flangeThickness
+  const yTopFlangeBottom = hd - profile.flangeThickness
+  const horizontalRadiusBudget = Math.max(0, profile.flangeWidth - profile.webThickness)
+  const innerVerticalBudget = Math.max(0, profile.depth - profile.flangeThickness)
+  const edgeVerticalBudget = Math.max(0, profile.flangeThickness)
+  const rawInner = Math.max(0, profile.filletRadius ?? 0)
+  const rawEdge = Math.max(0, profile.edgeRadius ?? 0)
+
+  let rEdge = Math.min(
+    rawEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rawInner),
+  )
+  const rInner = Math.min(
+    rawInner,
+    innerVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rEdge),
+  )
+  rEdge = Math.min(
+    rEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rInner),
+  )
+
+  if (rInner <= 1e-6 && rEdge <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: yTop },
+      { x: hweb, y: yTop },
+      { x: hweb, y: yBottomFlangeTop },
+      { x: hw, y: yBottomFlangeTop },
+      { x: hw, y: yBottom },
+      { x: -hweb, y: yBottom },
+      { x: -hweb, y: yTopFlangeBottom },
+      { x: -hw, y: yTopFlangeBottom },
+    ])
+  }
+
+  const pts: NormalizedVec2[] = [
+    { x: -hw, y: yTop },
+    { x: hweb, y: yTop },
+  ]
+
+  if (rInner > 1e-6) {
+    pts.push({ x: hweb, y: yBottomFlangeTop + rInner })
+    appendArc(
+      pts,
+      hweb + rInner,
+      yBottomFlangeTop + rInner,
+      rInner,
+      Math.PI,
+      (3 * Math.PI) / 2,
+    )
+  } else {
+    pts.push({ x: hweb, y: yBottomFlangeTop })
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw - rEdge, y: yBottomFlangeTop })
+    appendArc(
+      pts,
+      hw - rEdge,
+      yBottomFlangeTop - rEdge,
+      rEdge,
+      Math.PI / 2,
+      0,
+    )
+  } else {
+    pts.push({ x: hw, y: yBottomFlangeTop })
+  }
+
+  pts.push(
+    { x: hw, y: yBottom },
+    { x: -hweb, y: yBottom },
+  )
+
+  if (rInner > 1e-6) {
+    pts.push({ x: -hweb, y: yTopFlangeBottom - rInner })
+    appendArc(
+      pts,
+      -hweb - rInner,
+      yTopFlangeBottom - rInner,
+      rInner,
+      0,
+      Math.PI / 2,
+    )
+  } else {
+    pts.push({ x: -hweb, y: yTopFlangeBottom })
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: -hw + rEdge, y: yTopFlangeBottom })
+    appendArc(
+      pts,
+      -hw + rEdge,
+      yTopFlangeBottom + rEdge,
+      rEdge,
+      (3 * Math.PI) / 2,
+      Math.PI,
+    )
+  } else {
+    pts.push({ x: -hw, y: yTopFlangeBottom })
+  }
+
+  return ensureCounterClockwise(pts)
+}
+
 function uShapeLoop(profile: Extract<IfcAreaParameterizedProfileDef, { type: 'IfcUShapeProfileDef' }>): NormalizedVec2[] {
   const hd = profile.depth / 2
   const hw = profile.flangeWidth / 2
@@ -604,7 +716,7 @@ function applyPlacement2DToLoop(
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
  * Supported types: Rectangle, Circle, Ellipse, RectangleHollow,
- * CircleHollow, IShape (symmetric), TShape, UShape, LShape, CShape.
+ * CircleHollow, IShape (symmetric), TShape, UShape, ZShape, LShape, CShape.
  * Other parameterized types throw an Error.
  */
 export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): NormalizedProfile {
@@ -688,6 +800,10 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
 
     case 'IfcUShapeProfileDef':
       outerLoop = uShapeLoop(profile)
+      break
+
+    case 'IfcZShapeProfileDef':
+      outerLoop = zShapeLoop(profile)
       break
 
     case 'IfcLShapeProfileDef': {

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -14,6 +14,7 @@ import type {
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
   IfcUShapeProfileDef,
+  IfcZShapeProfileDef,
   Vec2,
 } from "../../types.ts";
 import {
@@ -455,6 +456,118 @@ function uShapeVec2(p: IfcUShapeProfileDef): Vec2[] {
   return ensureCounterClockwise(pts);
 }
 
+function zShapeVec2(p: IfcZShapeProfileDef): Vec2[] {
+  const hd = p.depth / 2;
+  const hweb = p.webThickness / 2;
+  const hw = p.flangeWidth - hweb;
+  const yTop = hd;
+  const yBottom = -hd;
+  const yBottomFlangeTop = -hd + p.flangeThickness;
+  const yTopFlangeBottom = hd - p.flangeThickness;
+  const horizontalRadiusBudget = Math.max(0, p.flangeWidth - p.webThickness);
+  const innerVerticalBudget = Math.max(0, p.depth - p.flangeThickness);
+  const edgeVerticalBudget = Math.max(0, p.flangeThickness);
+  const rawInner = Math.max(0, p.filletRadius ?? 0);
+  const rawEdge = Math.max(0, p.edgeRadius ?? 0);
+
+  let rEdge = Math.min(
+    rawEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rawInner),
+  );
+  const rInner = Math.min(
+    rawInner,
+    innerVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rEdge),
+  );
+  rEdge = Math.min(
+    rEdge,
+    edgeVerticalBudget,
+    Math.max(0, horizontalRadiusBudget - rInner),
+  );
+
+  if (rInner <= 1e-6 && rEdge <= 1e-6) {
+    return ensureCounterClockwise([
+      { x: -hw, y: yTop },
+      { x: hweb, y: yTop },
+      { x: hweb, y: yBottomFlangeTop },
+      { x: hw, y: yBottomFlangeTop },
+      { x: hw, y: yBottom },
+      { x: -hweb, y: yBottom },
+      { x: -hweb, y: yTopFlangeBottom },
+      { x: -hw, y: yTopFlangeBottom },
+    ]);
+  }
+
+  const pts: Vec2[] = [
+    { x: -hw, y: yTop },
+    { x: hweb, y: yTop },
+  ];
+
+  if (rInner > 1e-6) {
+    pts.push({ x: hweb, y: yBottomFlangeTop + rInner });
+    appendArc(
+      pts,
+      hweb + rInner,
+      yBottomFlangeTop + rInner,
+      rInner,
+      Math.PI,
+      (3 * Math.PI) / 2,
+    );
+  } else {
+    pts.push({ x: hweb, y: yBottomFlangeTop });
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: hw - rEdge, y: yBottomFlangeTop });
+    appendArc(
+      pts,
+      hw - rEdge,
+      yBottomFlangeTop - rEdge,
+      rEdge,
+      Math.PI / 2,
+      0,
+    );
+  } else {
+    pts.push({ x: hw, y: yBottomFlangeTop });
+  }
+
+  pts.push(
+    { x: hw, y: yBottom },
+    { x: -hweb, y: yBottom },
+  );
+
+  if (rInner > 1e-6) {
+    pts.push({ x: -hweb, y: yTopFlangeBottom - rInner });
+    appendArc(
+      pts,
+      -hweb - rInner,
+      yTopFlangeBottom - rInner,
+      rInner,
+      0,
+      Math.PI / 2,
+    );
+  } else {
+    pts.push({ x: -hweb, y: yTopFlangeBottom });
+  }
+
+  if (rEdge > 1e-6) {
+    pts.push({ x: -hw + rEdge, y: yTopFlangeBottom });
+    appendArc(
+      pts,
+      -hw + rEdge,
+      yTopFlangeBottom + rEdge,
+      rEdge,
+      (3 * Math.PI) / 2,
+      Math.PI,
+    );
+  } else {
+    pts.push({ x: -hw, y: yTopFlangeBottom });
+  }
+
+  return ensureCounterClockwise(pts);
+}
+
 // ── Public polygon accessors ───────────────────────────────────────────────
 
 /** Outer boundary of any profile as Vec2 list. */
@@ -496,6 +609,8 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
       return tShapeVec2(profile);
     case "IfcUShapeProfileDef":
       return uShapeVec2(profile);
+    case "IfcZShapeProfileDef":
+      return zShapeVec2(profile);
     case "IfcArbitraryClosedProfileDef":
     case "IfcArbitraryProfileDefWithVoids":
       return profile.outerCurve;

--- a/src/ifc/samples/extrusion.z-shape.ts
+++ b/src/ifc/samples/extrusion.z-shape.ts
@@ -1,0 +1,235 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcZShapeProfileDef",
+  profileType: "AREA",
+  depth: 5,
+  flangeWidth: 3.5,
+  webThickness: 0.6,
+  flangeThickness: 0.8,
+  filletRadius: 0.2,
+  edgeRadius: 0.15,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 6,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionZShapeSample: SampleDef = {
+  id: "extrusion-z-shape",
+  title: "Z-Shape Profile (IfcZShapeProfileDef)",
+  description:
+    "A Z-shaped cross-section defined by depth, flange width, web thickness, flange thickness, and optional corner radii (IfcZShapeProfileDef). " +
+    "Adjust the dimensions in the profile editor.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: Z-Shape Cross-Section",
+      description:
+        "IfcZShapeProfileDef defines two opposite flanges offset across a central web, creating a Z-shaped section. " +
+        "This sample also exposes the optional inner fillet radius and outer edge radius.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector specifies where the Z-shaped profile is swept. " +
+        "Use this step to inspect direction and depth before generating the final solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The Z-shaped cross-section is extruded along the Z-axis to produce a 3D solid (IfcExtrudedAreaSolid).",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["z-shape"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const zDepth =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.depth
+        : DEFAULT_PROFILE.depth;
+    const flangeWidth =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.flangeWidth
+        : DEFAULT_PROFILE.flangeWidth;
+    const webThickness =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.webThickness
+        : DEFAULT_PROFILE.webThickness;
+    const flangeThickness =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.flangeThickness
+        : DEFAULT_PROFILE.flangeThickness;
+    const filletRadius =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.filletRadius
+        : DEFAULT_PROFILE.filletRadius;
+    const edgeRadius =
+      activeProfile.type === "IfcZShapeProfileDef"
+        ? activeProfile.edgeRadius
+        : DEFAULT_PROFILE.edgeRadius;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcZShapeProfileDef",
+        profileType: "AREA",
+        depth: zDepth,
+        flangeWidth,
+        webThickness,
+        flangeThickness,
+        ...(filletRadius && filletRadius > 0 ? { filletRadius } : {}),
+        ...(edgeRadius && edgeRadius > 0 ? { edgeRadius } : {}),
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, activeProfile, "zshape_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcZShapeProfileDef",
+      profileType: "AREA",
+      depth: "(see profile editor)",
+      flangeWidth: "(see profile editor)",
+      webThickness: "(see profile editor)",
+      flangeThickness: "(see profile editor)",
+      filletRadius: "(see profile editor)",
+      edgeRadius: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type {
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
   IfcUShapeProfileDef,
+  IfcZShapeProfileDef,
 } from "./ifc/generated/schema.ts";
 
 // ── UI model coordinate types ──────────────────────────────────────────────
@@ -172,6 +173,7 @@ export type ProfileType =
   | "l-shape"
   | "t-shape"
   | "u-shape"
+  | "z-shape"
   | "arbitrary";
 
 export interface ProfileEditorConfig {

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -423,7 +423,7 @@ export class ProfileEditor {
       const zsWeb = Math.min(Math.max(p.webThickness, zsWebMin), zsWebMax);
 
       const zsFlangeMin = 0.05;
-      const zsFlangeRawMax = p.depth;
+      const zsFlangeRawMax = p.depth / 2 - zsFlangeMin;
       const zsFlangeMax = Math.max(zsFlangeMin, zsFlangeRawMax);
       const zsFlange = Math.min(
         Math.max(p.flangeThickness, zsFlangeMin),
@@ -769,7 +769,7 @@ export class ProfileEditor {
     this._bindSlider("zs-d", (v) => {
       const prof = this.currentProfile as IfcZShapeProfileDef;
       prof.depth = v;
-      const flangeMax = Math.max(0.05, prof.depth);
+      const flangeMax = Math.max(0.05, prof.depth / 2 - 0.05);
       prof.flangeThickness = this._clampDependentSlider("zs-ft", flangeMax);
       this._syncZShapeRadii();
     });

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -10,6 +10,7 @@ import type {
   IfcLShapeProfileDef,
   IfcTShapeProfileDef,
   IfcUShapeProfileDef,
+  IfcZShapeProfileDef,
   IfcArbitraryClosedProfileDef,
   Vec2,
 } from "../types.ts";
@@ -78,6 +79,8 @@ export class ProfileEditor {
         return "t-shape";
       case "IfcUShapeProfileDef":
         return "u-shape";
+      case "IfcZShapeProfileDef":
+        return "z-shape";
       case "IfcArbitraryClosedProfileDef":
       case "IfcArbitraryProfileDefWithVoids":
         return "arbitrary";
@@ -184,6 +187,18 @@ export class ProfileEditor {
           filletRadius: 0.2,
           edgeRadius: 0.15,
         } satisfies IfcUShapeProfileDef);
+        break;
+      case "z-shape":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcZShapeProfileDef",
+          profileType: "AREA",
+          depth: 5,
+          flangeWidth: 3.5,
+          webThickness: 0.6,
+          flangeThickness: 0.8,
+          filletRadius: 0.2,
+          edgeRadius: 0.15,
+        } satisfies IfcZShapeProfileDef);
         break;
       case "arbitrary":
         this.currentProfile = this._cloneProfile({
@@ -401,6 +416,42 @@ export class ProfileEditor {
       `;
     }
 
+    if (p.type === "IfcZShapeProfileDef") {
+      const zsWebMin = 0.05;
+      const zsWebRawMax = p.flangeWidth - zsWebMin;
+      const zsWebMax = Math.max(zsWebMin, zsWebRawMax);
+      const zsWeb = Math.min(Math.max(p.webThickness, zsWebMin), zsWebMax);
+
+      const zsFlangeMin = 0.05;
+      const zsFlangeRawMax = p.depth;
+      const zsFlangeMax = Math.max(zsFlangeMin, zsFlangeRawMax);
+      const zsFlange = Math.min(
+        Math.max(p.flangeThickness, zsFlangeMin),
+        zsFlangeMax,
+      );
+
+      p.webThickness = zsWeb;
+      p.flangeThickness = zsFlange;
+
+      p.edgeRadius = this._normalizeZShapeEdgeRadius();
+      p.filletRadius = this._normalizeZShapeFilletRadius();
+      p.edgeRadius = this._normalizeZShapeEdgeRadius();
+
+      const zsFilletMax = this._maxZShapeFilletRadius();
+      const zsEdgeMax = this._maxZShapeEdgeRadius();
+      const zsFillet = p.filletRadius ?? 0;
+      const zsEdge = p.edgeRadius ?? 0;
+
+      return `
+        ${this._sliderHTML("zs-d", "Depth", p.depth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("zs-fw", "Flange Width", p.flangeWidth, 0.5, 10, 0.1)}
+        ${this._sliderHTML("zs-wt", "Web Thickness", zsWeb, zsWebMin, zsWebMax, 0.05)}
+        ${this._sliderHTML("zs-ft", "Flange Thickness", zsFlange, zsFlangeMin, zsFlangeMax, 0.05)}
+        ${this._sliderHTML("zs-fr", "Fillet Radius", zsFillet, 0, zsFilletMax, 0.05)}
+        ${this._sliderHTML("zs-er", "Edge Radius", zsEdge, 0, zsEdgeMax, 0.05)}
+      `;
+    }
+
     if (
       p.type === "IfcArbitraryClosedProfileDef" ||
       p.type === "IfcArbitraryProfileDefWithVoids"
@@ -466,6 +517,7 @@ export class ProfileEditor {
       "l-shape": "L-Shape",
       "t-shape": "T-Shape",
       "u-shape": "U-Shape",
+      "z-shape": "Z-Shape",
       arbitrary: "Arbitrary",
     };
     return labels[t];
@@ -713,6 +765,40 @@ export class ProfileEditor {
         this._clampUShapeFilletRadius();
     });
 
+    // ── Z-Shape ──
+    this._bindSlider("zs-d", (v) => {
+      const prof = this.currentProfile as IfcZShapeProfileDef;
+      prof.depth = v;
+      const flangeMax = Math.max(0.05, prof.depth);
+      prof.flangeThickness = this._clampDependentSlider("zs-ft", flangeMax);
+      this._syncZShapeRadii();
+    });
+    this._bindSlider("zs-fw", (v) => {
+      const prof = this.currentProfile as IfcZShapeProfileDef;
+      prof.flangeWidth = v;
+      const webMax = Math.max(0.05, prof.flangeWidth - 0.05);
+      prof.webThickness = this._clampDependentSlider("zs-wt", webMax);
+      this._syncZShapeRadii();
+    });
+    this._bindSlider("zs-wt", (v) => {
+      (this.currentProfile as IfcZShapeProfileDef).webThickness = v;
+      this._syncZShapeRadii();
+    });
+    this._bindSlider("zs-ft", (v) => {
+      (this.currentProfile as IfcZShapeProfileDef).flangeThickness = v;
+      this._syncZShapeRadii();
+    });
+    this._bindSlider("zs-fr", (v) => {
+      (this.currentProfile as IfcZShapeProfileDef).filletRadius = v;
+      (this.currentProfile as IfcZShapeProfileDef).edgeRadius =
+        this._clampZShapeEdgeRadius();
+    });
+    this._bindSlider("zs-er", (v) => {
+      (this.currentProfile as IfcZShapeProfileDef).edgeRadius = v;
+      (this.currentProfile as IfcZShapeProfileDef).filletRadius =
+        this._clampZShapeFilletRadius();
+    });
+
     // ── Arbitrary point inputs ──
     for (const input of this.container.querySelectorAll<HTMLInputElement>(
       ".point-x-input, .point-y-input",
@@ -930,5 +1016,68 @@ export class ProfileEditor {
 
   private _clampUShapeEdgeRadius(): number {
     return this._clampDependentSlider("us-er", this._maxUShapeEdgeRadius());
+  }
+
+  private _maxZShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcZShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const edgeRadius = prof.edgeRadius ?? 0;
+    return Math.max(
+      0,
+      Math.min(
+        prof.flangeWidth - prof.webThickness - edgeRadius,
+        prof.depth - prof.flangeThickness,
+      ),
+    );
+  }
+
+  private _maxZShapeEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcZShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const filletRadius = prof.filletRadius ?? 0;
+    return Math.max(
+      0,
+      Math.min(
+        prof.flangeThickness,
+        prof.flangeWidth - prof.webThickness - filletRadius,
+      ),
+    );
+  }
+
+  private _normalizeZShapeFilletRadius(): number {
+    if (this.currentProfile.type !== "IfcZShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const next = Math.min(
+      Math.max(prof.filletRadius ?? 0, 0),
+      this._maxZShapeFilletRadius(),
+    );
+    prof.filletRadius = next;
+    return next;
+  }
+
+  private _normalizeZShapeEdgeRadius(): number {
+    if (this.currentProfile.type !== "IfcZShapeProfileDef") return 0;
+    const prof = this.currentProfile;
+    const next = Math.min(
+      Math.max(prof.edgeRadius ?? 0, 0),
+      this._maxZShapeEdgeRadius(),
+    );
+    prof.edgeRadius = next;
+    return next;
+  }
+
+  private _syncZShapeRadii(): void {
+    const prof = this.currentProfile as IfcZShapeProfileDef;
+    prof.edgeRadius = this._clampZShapeEdgeRadius();
+    prof.filletRadius = this._clampZShapeFilletRadius();
+    prof.edgeRadius = this._clampZShapeEdgeRadius();
+  }
+
+  private _clampZShapeFilletRadius(): number {
+    return this._clampDependentSlider("zs-fr", this._maxZShapeFilletRadius());
+  }
+
+  private _clampZShapeEdgeRadius(): number {
+    return this._clampDependentSlider("zs-er", this._maxZShapeEdgeRadius());
   }
 }


### PR DESCRIPTION
## Summary
- add `IfcZShapeProfileDef` support to the extrusion normalization path
- add matching outline/profile editor support so the example page renders instead of failing during overlay creation
- add a dedicated `IfcZShapeProfileDef` extrusion sample and register it in the app routes

## Root Cause
`IfcZShapeProfileDef` was added to the normalization layer, but the viewport overlay path still called `profileOuterVec2()` without a matching `IfcZShapeProfileDef` branch. That caused the example page to throw during initial render, so nothing was displayed.

## Validation
- `bun run build`
- `bun --eval 'import { profileOuterVec2 } from "./src/ifc/operations/extrusion.ts"; const pts = profileOuterVec2({ type: "IfcZShapeProfileDef", profileType: "AREA", depth: 5, flangeWidth: 3.5, webThickness: 0.6, flangeThickness: 0.8, filletRadius: 0.2, edgeRadius: 0.15 }); console.log(pts.length)'`
