### PR TITLE
[codex] Add IfcRoundedRectangleProfileDef extrusion support

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -2,6 +2,7 @@ import { routes } from "./routes.ts";
 import { HomePage } from "../pages/HomePage.ts";
 import { ExamplePage } from "../pages/ExamplePage.ts";
 import { extrusionRectangleSample } from "../ifc/samples/extrusion.rectangle.ts";
+import { extrusionRoundedRectangleSample } from "../ifc/samples/extrusion.rounded-rectangle.ts";
 import { booleanDifferenceSample } from "../ifc/samples/boolean.difference.ts";
 import { extrusionCircleSample } from "../ifc/samples/extrusion.circle.ts";
 import { extrusionEllipseSample } from "../ifc/samples/extrusion.ellipse.ts";
@@ -18,6 +19,7 @@ import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
   "extrusion-rectangle": extrusionRectangleSample,
+  "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,
   "extrusion-circle": extrusionCircleSample,
   "extrusion-ellipse": extrusionEllipseSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -63,6 +63,16 @@ export const routes: Route[] = [
     status: "available",
   },
   {
+    hash: "#/examples/extrusion-rounded-rectangle",
+    title: "Rounded Rectangle Profile (IfcRoundedRectangleProfileDef)",
+    description:
+      "Extrudes a rounded rectangular cross-section into a 3D solid (IfcExtrudedAreaSolid + IfcRoundedRectangleProfileDef).",
+    sampleId: "extrusion-rounded-rectangle",
+    category: "ExtrudedAreaSolid",
+    difficulty: "beginner",
+    status: "available",
+  },
+  {
     hash: "#/examples/swept-disk",
     title: "Swept Disk Solid",
     description:

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -756,7 +756,7 @@ function applyPlacement2DToLoop(
  * Normalize a generated-schema area profile into outer/inner planar loops.
  * The optional 2D placement on the profile is applied to all loop vertices.
  *
- * Supported types: Rectangle, Circle, Ellipse, RectangleHollow,
+ * Supported types: Rectangle, RoundedRectangle, Circle, Ellipse, RectangleHollow,
  * CircleHollow, IShape (symmetric), TShape, UShape, ZShape, LShape, CShape.
  * Other parameterized types throw an Error.
  */

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -227,6 +227,47 @@ function ellipseLoop(
   return pts
 }
 
+function roundedRectangleLoop(
+  xDim: number,
+  yDim: number,
+  roundingRadius: number,
+): NormalizedVec2[] {
+  const hw = xDim / 2
+  const hd = yDim / 2
+  const radius = Math.max(0, Math.min(roundingRadius, hw, hd))
+
+  if (radius <= 1e-6) {
+    return [
+      { x: -hw, y: -hd }, { x: hw, y: -hd },
+      { x:  hw, y:  hd }, { x: -hw, y:  hd },
+    ]
+  }
+
+  const pts: NormalizedVec2[] = [
+    { x: -hw + radius, y: -hd },
+    { x:  hw - radius, y: -hd },
+  ]
+
+  appendArc(pts, hw - radius, -hd + radius, radius, -Math.PI / 2, 0)
+  pts.push({ x: hw, y: hd - radius })
+  appendArc(pts, hw - radius, hd - radius, radius, 0, Math.PI / 2)
+  pts.push({ x: -hw + radius, y: hd })
+  appendArc(pts, -hw + radius, hd - radius, radius, Math.PI / 2, Math.PI)
+  pts.push({ x: -hw, y: -hd + radius })
+  appendArc(
+    pts,
+    -hw + radius,
+    -hd + radius,
+    radius,
+    Math.PI,
+    (3 * Math.PI) / 2,
+  )
+  // The last arc ends at (-hw + radius, -hd), which matches pts[0].
+  pts.pop()
+
+  return ensureCounterClockwise(pts)
+}
+
 function polygonSignedArea(pts: NormalizedVec2[]): number {
   let area = 0
   for (let i = 0; i < pts.length; i++) {
@@ -737,6 +778,14 @@ export function normalizeProfileDef(profile: IfcAreaParameterizedProfileDef): No
       ]
       break
     }
+
+    case 'IfcRoundedRectangleProfileDef':
+      outerLoop = roundedRectangleLoop(
+        profile.xDim,
+        profile.yDim,
+        profile.roundingRadius,
+      )
+      break
 
     case 'IfcCircleProfileDef':
       outerLoop = circleLoop(profile.radius)

--- a/src/ifc/operations/extrusion.ts
+++ b/src/ifc/operations/extrusion.ts
@@ -66,6 +66,49 @@ function ellipseVec2(
   return pts;
 }
 
+function roundedRectangleVec2(
+  xDim: number,
+  yDim: number,
+  roundingRadius: number,
+): Vec2[] {
+  const hw = xDim / 2;
+  const hd = yDim / 2;
+  const radius = Math.max(0, Math.min(roundingRadius, hw, hd));
+
+  if (radius <= 1e-6) {
+    return [
+      { x: -hw, y: -hd },
+      { x: hw, y: -hd },
+      { x: hw, y: hd },
+      { x: -hw, y: hd },
+    ];
+  }
+
+  const pts: Vec2[] = [
+    { x: -hw + radius, y: -hd },
+    { x: hw - radius, y: -hd },
+  ];
+
+  appendArc(pts, hw - radius, -hd + radius, radius, -Math.PI / 2, 0);
+  pts.push({ x: hw, y: hd - radius });
+  appendArc(pts, hw - radius, hd - radius, radius, 0, Math.PI / 2);
+  pts.push({ x: -hw + radius, y: hd });
+  appendArc(pts, -hw + radius, hd - radius, radius, Math.PI / 2, Math.PI);
+  pts.push({ x: -hw, y: -hd + radius });
+  appendArc(
+    pts,
+    -hw + radius,
+    -hd + radius,
+    radius,
+    Math.PI,
+    (3 * Math.PI) / 2,
+  );
+  // The last arc ends at (-hw + radius, -hd), which matches pts[0].
+  pts.pop();
+
+  return ensureCounterClockwise(pts);
+}
+
 function polygonSignedArea(pts: Vec2[]): number {
   let area = 0;
   for (let i = 0; i < pts.length; i++) {
@@ -583,6 +626,12 @@ export function profileOuterVec2(profile: IfcProfileDef): Vec2[] {
         { x: -hw, y: hd },
       ];
     }
+    case "IfcRoundedRectangleProfileDef":
+      return roundedRectangleVec2(
+        profile.xDim,
+        profile.yDim,
+        profile.roundingRadius,
+      );
     case "IfcRectangleHollowProfileDef": {
       const hw = profile.xDim / 2,
         hd = profile.yDim / 2;

--- a/src/ifc/samples/extrusion.rounded-rectangle.ts
+++ b/src/ifc/samples/extrusion.rounded-rectangle.ts
@@ -1,0 +1,223 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  ExtrusionParams,
+  Vec3,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { buildExtrusionMesh } from "../operations/extrusion.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildExtrusionDirectionOverlay,
+} from "../../engine/overlays.ts";
+import type { IfcExtrudedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_X_DIM = 4;
+const DEFAULT_Y_DIM = 3;
+const DEFAULT_ROUNDING_RADIUS = 0.5;
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcRoundedRectangleProfileDef",
+  profileType: "AREA",
+  xDim: DEFAULT_X_DIM,
+  yDim: DEFAULT_Y_DIM,
+  roundingRadius: DEFAULT_ROUNDING_RADIUS,
+};
+
+const DEFAULT_EXTRUSION: ExtrusionParams = {
+  depth: 5,
+  extrudedDirection: { x: 0, y: 0, z: 1 },
+};
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export const extrusionRoundedRectangleSample: SampleDef = {
+  id: "extrusion-rounded-rectangle",
+  title: "Rounded Rectangle Profile (IfcRoundedRectangleProfileDef)",
+  description:
+    "A rounded rectangular cross-section extruded along the Z-axis into a 3D solid. " +
+    "Edit xDim, yDim, and the corner radius in the profile editor.",
+  parameters: [],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: Rounded Rectangle Profile",
+      description:
+        "IfcRoundedRectangleProfileDef defines a rectangular cross-section by xDim and yDim, with arcs at the corners controlled by roundingRadius. " +
+        "Edit those values in the profile editor above.",
+    },
+    {
+      id: "direction",
+      label: "Step 2: Extruded Direction",
+      description:
+        "The extrusion direction vector defines where the rounded profile will be swept. " +
+        "Adjust direction and depth to inspect how IfcExtrudedAreaSolid is configured before generating the solid.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Extruded Solid",
+      description:
+        "The rounded rectangle is extruded along the Z-axis by the given depth to produce a prismatic solid with filleted corners. " +
+        "This is equivalent to IfcExtrudedAreaSolid applied to an IfcRoundedRectangleProfileDef.",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["rounded-rectangle"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  extrusionEditorConfig: {
+    defaultExtrusion: DEFAULT_EXTRUSION,
+  },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const depth = extrusion?.depth ?? DEFAULT_EXTRUSION.depth;
+    const extrusionDirection =
+      extrusion?.extrudedDirection ?? DEFAULT_EXTRUSION.extrudedDirection;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activeProfile: IfcProfileDef = profile ?? DEFAULT_PROFILE;
+    const xDim =
+      activeProfile.type === "IfcRoundedRectangleProfileDef"
+        ? activeProfile.xDim
+        : DEFAULT_X_DIM;
+    const yDim =
+      activeProfile.type === "IfcRoundedRectangleProfileDef"
+        ? activeProfile.yDim
+        : DEFAULT_Y_DIM;
+    const roundingRadius =
+      activeProfile.type === "IfcRoundedRectangleProfileDef"
+        ? activeProfile.roundingRadius
+        : DEFAULT_ROUNDING_RADIUS;
+
+    const generatedSolid: IfcExtrudedAreaSolid = {
+      type: "IfcExtrudedAreaSolid",
+      sweptArea: {
+        type: "IfcRoundedRectangleProfileDef",
+        profileType: "AREA",
+        xDim,
+        yDim,
+        roundingRadius,
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
+        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
+      },
+      extrudedDirection: {
+        type: "IfcDirection",
+        directionRatios: [
+          extrusionDirection.x,
+          extrusionDirection.y,
+          extrusionDirection.z,
+        ],
+      },
+      depth,
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(
+          scene,
+          activeProfile,
+          "rounded_rectangle_outline",
+        ),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const arrow = buildExtrusionDirectionOverlay(
+        scene,
+        { x: 0, y: 0, z: 0 },
+        extrusionDirection,
+        depth,
+        "dir_arrow",
+        activePlacement,
+      );
+      if (arrow) meshes.push(arrow);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildExtrusionMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "extrusion_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (_params: ParamValues) => ({
+    type: "IfcExtrudedAreaSolid",
+    sweptArea: {
+      type: "IfcRoundedRectangleProfileDef",
+      profileType: "AREA",
+      xDim: "(see profile editor)",
+      yDim: "(see profile editor)",
+      roundingRadius: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
+    },
+    extrudedDirection: {
+      type: "IfcDirection",
+      directionRatios: "(see extrusion editor)",
+    },
+    depth: "(see extrusion editor)",
+  }),
+};

--- a/src/ifc/schema.ts
+++ b/src/ifc/schema.ts
@@ -25,6 +25,7 @@ export type {
 export type {
   IfcCShapeProfileDef,
   IfcRectangleProfileDef,
+  IfcRoundedRectangleProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,
   IfcCircleHollowProfileDef,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type {
   IfcProfileTypeEnum,
   IfcCShapeProfileDef,
   IfcRectangleProfileDef,
+  IfcRoundedRectangleProfileDef,
   IfcRectangleHollowProfileDef,
   IfcCircleProfileDef,
   IfcCircleHollowProfileDef,
@@ -164,6 +165,7 @@ export interface StepDef {
 /** Which profile types the ProfileEditor should expose for a given sample. */
 export type ProfileType =
   | "rectangle"
+  | "rounded-rectangle"
   | "circle"
   | "ellipse"
   | "rect-hollow"

--- a/src/ui/ProfileEditor.ts
+++ b/src/ui/ProfileEditor.ts
@@ -1,6 +1,7 @@
 import type {
   IfcProfileDef,
   IfcRectangleProfileDef,
+  IfcRoundedRectangleProfileDef,
   IfcCircleProfileDef,
   IfcEllipseProfileDef,
   IfcRectangleHollowProfileDef,
@@ -61,6 +62,8 @@ export class ProfileEditor {
     switch (this.currentProfile.type) {
       case "IfcRectangleProfileDef":
         return "rectangle";
+      case "IfcRoundedRectangleProfileDef":
+        return "rounded-rectangle";
       case "IfcCircleProfileDef":
         return "circle";
       case "IfcEllipseProfileDef":
@@ -100,6 +103,15 @@ export class ProfileEditor {
           xDim: 4,
           yDim: 3,
         } satisfies IfcRectangleProfileDef);
+        break;
+      case "rounded-rectangle":
+        this.currentProfile = this._cloneProfile({
+          type: "IfcRoundedRectangleProfileDef",
+          profileType: "AREA",
+          xDim: 4,
+          yDim: 3,
+          roundingRadius: 0.5,
+        } satisfies IfcRoundedRectangleProfileDef);
         break;
       case "circle":
         this.currentProfile = this._cloneProfile({
@@ -221,6 +233,20 @@ export class ProfileEditor {
       return `
         ${this._sliderHTML("rect-w", "xDim", p.xDim, 0.5, 10, 0.1)}
         ${this._sliderHTML("rect-h", "yDim", p.yDim, 0.5, 10, 0.1)}
+      `;
+    }
+
+    if (p.type === "IfcRoundedRectangleProfileDef") {
+      const rrRadiusMax = Math.max(0, Math.min(p.xDim, p.yDim) / 2);
+      const rrRadius = Math.min(
+        Math.max(p.roundingRadius, 0),
+        rrRadiusMax,
+      );
+      p.roundingRadius = rrRadius;
+      return `
+        ${this._sliderHTML("rr-w", "xDim", p.xDim, 0.5, 10, 0.1)}
+        ${this._sliderHTML("rr-h", "yDim", p.yDim, 0.5, 10, 0.1)}
+        ${this._sliderHTML("rr-r", "Rounding Radius", rrRadius, 0, rrRadiusMax, 0.05)}
       `;
     }
 
@@ -508,6 +534,7 @@ export class ProfileEditor {
   private _typeLabel(t: ProfileType): string {
     const labels: Record<ProfileType, string> = {
       rectangle: "Rectangle",
+      "rounded-rectangle": "Rounded Rectangle",
       circle: "Circle",
       ellipse: "Ellipse",
       "rect-hollow": "Rect Hollow",
@@ -563,6 +590,23 @@ export class ProfileEditor {
     });
     this._bindSlider("rect-h", (v) => {
       (this.currentProfile as IfcRectangleProfileDef).yDim = v;
+    });
+
+    // ── Rounded Rectangle ──
+    this._bindSlider("rr-w", (v) => {
+      const prof = this.currentProfile as IfcRoundedRectangleProfileDef;
+      prof.xDim = v;
+      const max = Math.max(0, Math.min(prof.xDim, prof.yDim) / 2);
+      prof.roundingRadius = this._clampDependentSlider("rr-r", max);
+    });
+    this._bindSlider("rr-h", (v) => {
+      const prof = this.currentProfile as IfcRoundedRectangleProfileDef;
+      prof.yDim = v;
+      const max = Math.max(0, Math.min(prof.xDim, prof.yDim) / 2);
+      prof.roundingRadius = this._clampDependentSlider("rr-r", max);
+    });
+    this._bindSlider("rr-r", (v) => {
+      (this.currentProfile as IfcRoundedRectangleProfileDef).roundingRadius = v;
     });
 
     // ── Circle ──


### PR DESCRIPTION
## What changed
- add `IfcRoundedRectangleProfileDef` support to profile normalization and extrusion outline generation
- add a new rounded rectangle extrusion sample and route so the shape can be explored in the playground UI
- extend the profile editor with rounded rectangle controls and radius clamping

## Why
The playground already supports several `IfcExtrudedAreaSolid` profile types, but it could not visualize rounded rectangle profiles. This PR fills that gap so we can inspect the generated geometry and interactively adjust `xDim`, `yDim`, and `roundingRadius`.

## Impact
- users can open a dedicated rounded rectangle example in the examples list
- the editor now exposes rounded rectangle profile creation and keeps the corner radius within valid bounds
- extrusion/profile overlay paths stay consistent for this profile type

## Validation
- `bun run build`
