### PR TITLE
[codex] Add IfcRevolvedAreaSolid schema generation

### DIFF
--- a/scripts/generate_ifc_schema.py
+++ b/scripts/generate_ifc_schema.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Generate IFC schema JSON and TypeScript type definitions from IfcOpenShell.
 
-Extracts attribute metadata for IfcExtrudedAreaSolid and all supported
-subclasses of IfcParameterizedProfileDef (excluding explicitly unsupported
-entities such as IfcTrapeziumProfileDef), plus the supporting geometry entities.
+Extracts attribute metadata for IfcExtrudedAreaSolid, IfcRevolvedAreaSolid,
+and all supported subclasses of IfcParameterizedProfileDef (excluding
+explicitly unsupported entities such as IfcTrapeziumProfileDef), plus the
+supporting geometry entities.
 
 Outputs:
   src/ifc/generated/schema.json  — raw IFC4 attribute schema (PascalCase)
@@ -34,6 +35,7 @@ OUTPUT_DIR = REPO_ROOT / "src" / "ifc" / "generated"
 GEOMETRY_ENTITIES = [
     "IfcCartesianPoint",
     "IfcDirection",
+    "IfcAxis1Placement",
     "IfcAxis2Placement2D",
     "IfcAxis2Placement3D",
 ]
@@ -44,7 +46,13 @@ UNSUPPORTED_PROFILE_ENTITIES = frozenset({"IfcTrapeziumProfileDef"})
 
 SOLID_ENTITIES = [
     "IfcExtrudedAreaSolid",
+    "IfcRevolvedAreaSolid",
 ]
+
+# Swept-area solids require an AREA profile by formal proposition, so we
+# narrow SweptArea from the broad IfcProfileDef select to supported area
+# parameterized profiles in generated TypeScript interfaces.
+AREA_PROFILE_SOLID_ENTITIES = frozenset({"IfcExtrudedAreaSolid", "IfcRevolvedAreaSolid"})
 
 # IFC attribute names that carry no geometric meaning and are omitted from
 # the generated TypeScript (e.g. human-readable labels).
@@ -347,7 +355,7 @@ def generate_ts_file(schema, profile_entities: list[str]) -> str:
             # supported parameterized AREA profiles; swept-area solids require
             # SweptArea.ProfileType = AREA by formal proposition.
             # Ref: https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcSweptAreaSolid.htm#:~:text=SweptAreaType,IfcProfileTypeEnum.Area
-            if ifc_name == "IfcExtrudedAreaSolid" and attr_name == "SweptArea":
+            if ifc_name in AREA_PROFILE_SOLID_ENTITIES and attr_name == "SweptArea":
                 ts_type = "IfcAreaParameterizedProfileDef"
             else:
                 ts_type = type_info_to_ts(type_info)

--- a/src/ifc/generated/schema.json
+++ b/src/ifc/generated/schema.json
@@ -37,6 +37,28 @@
         }
       ]
     },
+    "IfcAxis1Placement": {
+      "name": "IfcAxis1Placement",
+      "supertype": "IfcPlacement",
+      "attributes": [
+        {
+          "name": "Location",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPoint"
+          }
+        },
+        {
+          "name": "Axis",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcDirection"
+          }
+        }
+      ]
+    },
     "IfcAxis2Placement2D": {
       "name": "IfcAxis2Placement2D",
       "supertype": "IfcPlacement",
@@ -1101,6 +1123,44 @@
           "type": {
             "kind": "number",
             "ifcType": "IfcPositiveLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcRevolvedAreaSolid": {
+      "name": "IfcRevolvedAreaSolid",
+      "supertype": "IfcSweptAreaSolid",
+      "attributes": [
+        {
+          "name": "SweptArea",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcProfileDef"
+          }
+        },
+        {
+          "name": "Position",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcAxis2Placement3D"
+          }
+        },
+        {
+          "name": "Axis",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcAxis1Placement"
+          }
+        },
+        {
+          "name": "Angle",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcPlaneAngleMeasure"
           }
         }
       ]

--- a/src/ifc/generated/schema.ts
+++ b/src/ifc/generated/schema.ts
@@ -18,6 +18,12 @@ export interface IfcDirection {
   directionRatios: number[];
 }
 
+export interface IfcAxis1Placement {
+  type: 'IfcAxis1Placement';
+  location: IfcCartesianPoint;
+  axis?: IfcDirection;
+}
+
 export interface IfcAxis2Placement2D {
   type: 'IfcAxis2Placement2D';
   location: IfcCartesianPoint;
@@ -208,4 +214,12 @@ export interface IfcExtrudedAreaSolid {
   position?: IfcAxis2Placement3D;
   extrudedDirection: IfcDirection;
   depth: number;
+}
+
+export interface IfcRevolvedAreaSolid {
+  type: 'IfcRevolvedAreaSolid';
+  sweptArea: IfcAreaParameterizedProfileDef;
+  position?: IfcAxis2Placement3D;
+  axis: IfcAxis1Placement;
+  angle: number;
 }


### PR DESCRIPTION
## Summary
- add `IfcRevolvedAreaSolid` to the IFC schema generator solid targets
- include `IfcAxis1Placement` in generated support geometry because `IfcRevolvedAreaSolid.Axis` depends on it
- regenerate `src/ifc/generated/schema.json` and `src/ifc/generated/schema.ts`

## Why
The playground only generated schema types for `IfcExtrudedAreaSolid`, which blocked follow-up work on `IfcRevolvedAreaSolid`. This PR adds the schema generation needed to implement the revolved solid safely in later changes.

## Impact
- `IfcRevolvedAreaSolid` is now available in generated JSON/TypeScript schema output
- `SweptArea` is constrained to supported AREA parameterized profiles for both extruded and revolved area solids
- generated TypeScript now also includes `IfcAxis1Placement`

## Validation
- `uv run python scripts/generate_ifc_schema.py`
- `bun run build`