### PR TITLE
[codex] Implement IfcRevolvedAreaSolid

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -16,6 +16,7 @@ import { extrusionTShapeSample } from "../ifc/samples/extrusion.t-shape.ts";
 import { extrusionUShapeSample } from "../ifc/samples/extrusion.u-shape.ts";
 import { extrusionZShapeSample } from "../ifc/samples/extrusion.z-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
+import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
@@ -34,6 +35,7 @@ const samples: Record<string, SampleDef> = {
   "extrusion-u-shape": extrusionUShapeSample,
   "extrusion-z-shape": extrusionZShapeSample,
   "swept-disk-basic": sweptDiskBasicSample,
+  "revolved-rectangle": revolvedRectangleSample,
 };
 
 export class App {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -87,9 +87,10 @@ export const routes: Route[] = [
     title: "Revolved Area Solid",
     description:
       "Revolves a 2D profile around an axis to create a 3D solid (IfcRevolvedAreaSolid).",
+    sampleId: "revolved-rectangle",
     category: "Revolved Area Solid",
     difficulty: "intermediate",
-    status: "planned",
+    status: "available",
   },
   {
     hash: "#/examples/boolean",

--- a/src/engine/overlays.ts
+++ b/src/engine/overlays.ts
@@ -208,6 +208,34 @@ export function buildExtrusionDirectionOverlay(
 }
 
 /**
+ * Build a 3D arrow overlay that visualises a revolution axis.
+ *
+ * When `placement` is provided, the axis origin and direction are interpreted
+ * in that local placement frame and transformed to world space first.
+ */
+export function buildRevolutionAxisOverlay(
+  scene: Scene,
+  origin: Vec3,
+  direction: Vec3,
+  length: number,
+  name: string,
+  placement?: IfcAxis2Placement3D,
+): Mesh | null {
+  const worldOrigin = transformPointByPlacement(origin, placement);
+  const worldDirection = transformVectorByPlacement(direction, placement);
+  const ifcDirection = toIfcMathVector(worldDirection);
+  if (ifcDirection.length() < MIN_DIRECTION_LENGTH) return null;
+  return createArrow(
+    scene,
+    ifcToBabylonVector(worldOrigin),
+    ifcToBabylonVector(worldDirection),
+    length,
+    new Color3(1, 0.75, 0.2),
+    name,
+  );
+}
+
+/**
  * Build 3 coloured arrows representing the local coordinate frame defined
  * by an `IfcAxis2Placement3D`.
  *

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -8,11 +8,13 @@
 import type {
   IfcCartesianPoint,
   IfcDirection,
+  IfcAxis1Placement,
   IfcAxis2Placement2D,
   IfcAxis2Placement3D,
   IfcAreaParameterizedProfileDef,
   IfcAsymmetricIShapeProfileDef,
   IfcExtrudedAreaSolid,
+  IfcRevolvedAreaSolid,
 } from './generated/schema.ts'
 
 // ── Internal geometry model ───────────────────────────────────────────────
@@ -46,6 +48,13 @@ export interface NormalizedPlacement3D {
   xAxis: NormalizedVec3;
 }
 
+/** A normalized 3D axis placement used by revolution-based solids. */
+export interface NormalizedAxis1Placement {
+  origin: NormalizedVec3;
+  /** Unit vector along the revolution axis. Defaults to (0, 0, 1). */
+  axis: NormalizedVec3;
+}
+
 /** A profile normalized into closed planar loops ready for triangulation. */
 export interface NormalizedProfile {
   /** Outer boundary polygon (counter-clockwise winding). */
@@ -64,6 +73,18 @@ export interface NormalizedExtrusion {
   extrusionDirection: NormalizedVec3;
   /** Length of the extrusion. */
   depth: number;
+}
+
+/** A renderer-friendly revolution specification. */
+export interface NormalizedRevolution {
+  /** Normalized cross-section profile. */
+  profile: NormalizedProfile;
+  /** 3D placement of the solid's local coordinate system. */
+  placement: NormalizedPlacement3D;
+  /** Axis of revolution expressed in placement-local coordinates. */
+  axis: NormalizedAxis1Placement;
+  /** Signed revolution angle in radians. */
+  angle: number;
 }
 
 // ── Vector helpers ────────────────────────────────────────────────────────
@@ -186,6 +207,16 @@ export function normalizePlacement3D(p: IfcAxis2Placement3D): NormalizedPlacemen
     origin: normalizePoint3(p.location),
     zAxis,
     xAxis: orthogonalizeXAxis(zAxis, refDirection),
+  }
+}
+
+/** Convert an IfcAxis1Placement to a normalized origin + unit-axis pair. */
+export function normalizeAxis1Placement(p: IfcAxis1Placement): NormalizedAxis1Placement {
+  return {
+    origin: normalizePoint3(p.location),
+    axis: p.axis
+      ? normalizeDirection3(p.axis, { x: 0, y: 0, z: 1 })
+      : { x: 0, y: 0, z: 1 },
   }
 }
 
@@ -1102,5 +1133,20 @@ export function normalizeExtrudedAreaSolid(solid: IfcExtrudedAreaSolid): Normali
       : defaultPlacement3D(),
     extrusionDirection: normalizeDirection3(solid.extrudedDirection),
     depth: solid.depth,
+  }
+}
+
+/**
+ * Convert a generated-schema IfcRevolvedAreaSolid to a NormalizedRevolution
+ * ready for consumption by a mesh builder.
+ */
+export function normalizeRevolvedAreaSolid(solid: IfcRevolvedAreaSolid): NormalizedRevolution {
+  return {
+    profile: normalizeProfileDef(solid.sweptArea),
+    placement: solid.position
+      ? normalizePlacement3D(solid.position)
+      : defaultPlacement3D(),
+    axis: normalizeAxis1Placement(solid.axis),
+    angle: solid.angle,
   }
 }

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -210,16 +210,37 @@ export function normalizePlacement3D(p: IfcAxis2Placement3D): NormalizedPlacemen
   }
 }
 
+/**
+ * Normalize a fallback axis vector: returns a unit-vector copy of `axis`.
+ * If `axis` is zero-length or non-finite, returns a copy of `fallback`.
+ */
+function normalizeFallbackAxis3(
+  axis: NormalizedVec3,
+  fallback: NormalizedVec3 = { x: 0, y: 0, z: 1 },
+): NormalizedVec3 {
+  const length = Math.hypot(axis.x, axis.y, axis.z)
+  if (!Number.isFinite(length) || length === 0) {
+    return { x: fallback.x, y: fallback.y, z: fallback.z }
+  }
+  return {
+    x: axis.x / length,
+    y: axis.y / length,
+    z: axis.z / length,
+  }
+}
+
 /** Convert an IfcAxis1Placement to a normalized origin + unit-axis pair. */
 export function normalizeAxis1Placement(
   p: IfcAxis1Placement,
   fallbackAxis: NormalizedVec3 = { x: 0, y: 0, z: 1 },
 ): NormalizedAxis1Placement {
+  const normalizedFallbackAxis = normalizeFallbackAxis3(fallbackAxis)
+
   return {
     origin: normalizePoint3(p.location),
     axis: p.axis
-      ? normalizeDirection3(p.axis, fallbackAxis)
-      : fallbackAxis,
+      ? normalizeDirection3(p.axis, normalizedFallbackAxis)
+      : normalizedFallbackAxis,
   }
 }
 
@@ -1144,7 +1165,7 @@ export function normalizeExtrudedAreaSolid(solid: IfcExtrudedAreaSolid): Normali
  * ready for consumption by a mesh builder.
  */
 export function normalizeRevolvedAreaSolid(solid: IfcRevolvedAreaSolid): NormalizedRevolution {
-  const axis = normalizeAxis1Placement(solid.axis, { x: 0, y: 1, z: 0 })
+  const axis = normalizeAxis1Placement(solid.axis, { x: 0, y: 0, z: 1 })
   if (Math.abs(axis.axis.z) > 1e-9) {
     throw new Error(
       "IfcRevolvedAreaSolid.Axis direction must be parallel to the local XY plane (axis.z = 0).",

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -211,12 +211,15 @@ export function normalizePlacement3D(p: IfcAxis2Placement3D): NormalizedPlacemen
 }
 
 /** Convert an IfcAxis1Placement to a normalized origin + unit-axis pair. */
-export function normalizeAxis1Placement(p: IfcAxis1Placement): NormalizedAxis1Placement {
+export function normalizeAxis1Placement(
+  p: IfcAxis1Placement,
+  fallbackAxis: NormalizedVec3 = { x: 0, y: 0, z: 1 },
+): NormalizedAxis1Placement {
   return {
     origin: normalizePoint3(p.location),
     axis: p.axis
-      ? normalizeDirection3(p.axis, { x: 0, y: 0, z: 1 })
-      : { x: 0, y: 0, z: 1 },
+      ? normalizeDirection3(p.axis, fallbackAxis)
+      : fallbackAxis,
   }
 }
 
@@ -1141,12 +1144,24 @@ export function normalizeExtrudedAreaSolid(solid: IfcExtrudedAreaSolid): Normali
  * ready for consumption by a mesh builder.
  */
 export function normalizeRevolvedAreaSolid(solid: IfcRevolvedAreaSolid): NormalizedRevolution {
+  const axis = normalizeAxis1Placement(solid.axis, { x: 0, y: 1, z: 0 })
+  if (Math.abs(axis.axis.z) > 1e-9) {
+    throw new Error(
+      "IfcRevolvedAreaSolid.Axis direction must be parallel to the local XY plane (axis.z = 0).",
+    )
+  }
+  if (Math.abs(axis.origin.z) > 1e-9) {
+    throw new Error(
+      "IfcRevolvedAreaSolid.Axis location must lie in the local XY plane (location.z = 0).",
+    )
+  }
+
   return {
     profile: normalizeProfileDef(solid.sweptArea),
     placement: solid.position
       ? normalizePlacement3D(solid.position)
       : defaultPlacement3D(),
-    axis: normalizeAxis1Placement(solid.axis),
+    axis,
     angle: solid.angle,
   }
 }

--- a/src/ifc/operations/revolution.ts
+++ b/src/ifc/operations/revolution.ts
@@ -1,0 +1,392 @@
+import { Mesh, Vector3, VertexBuffer, VertexData } from "@babylonjs/core";
+import type { Scene, StandardMaterial } from "@babylonjs/core";
+import earcut from "earcut";
+import {
+  normalizeRevolvedAreaSolid,
+  type NormalizedPlacement3D,
+  type NormalizedProfile,
+  type NormalizedRevolution,
+  type NormalizedVec2,
+  type NormalizedVec3,
+} from "../normalize.ts";
+import type { IfcRevolvedAreaSolid as IfcGeneratedRevolvedAreaSolid } from "../generated/schema.ts";
+import {
+  ifcToBabylonVector,
+  toIfcMathVector,
+} from "../../engine/ifc-coordinates.ts";
+
+const EPSILON = 1e-9;
+const FULL_REVOLUTION_EPSILON = 1e-5;
+const FULL_CIRCLE_SEGMENTS = 48;
+
+function add3(a: NormalizedVec3, b: NormalizedVec3): NormalizedVec3 {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function sub3(a: NormalizedVec3, b: NormalizedVec3): NormalizedVec3 {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function scale3(v: NormalizedVec3, scalar: number): NormalizedVec3 {
+  return { x: v.x * scalar, y: v.y * scalar, z: v.z * scalar };
+}
+
+function dot3(a: NormalizedVec3, b: NormalizedVec3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function cross3(a: NormalizedVec3, b: NormalizedVec3): NormalizedVec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function magnitude3(v: NormalizedVec3): number {
+  return Math.hypot(v.x, v.y, v.z);
+}
+
+function normalize3(
+  v: NormalizedVec3,
+  fallback: NormalizedVec3 = { x: 0, y: 0, z: 1 },
+): NormalizedVec3 {
+  const len = magnitude3(v);
+  if (len < EPSILON) return fallback;
+  return { x: v.x / len, y: v.y / len, z: v.z / len };
+}
+
+function vec2ToLocalPoint(v: NormalizedVec2): NormalizedVec3 {
+  return { x: v.x, y: v.y, z: 0 };
+}
+
+function rotateVectorAroundAxis(
+  vector: NormalizedVec3,
+  axis: NormalizedVec3,
+  angle: number,
+): NormalizedVec3 {
+  const k = normalize3(axis);
+  const cosTheta = Math.cos(angle);
+  const sinTheta = Math.sin(angle);
+  const parallel = scale3(k, dot3(k, vector) * (1 - cosTheta));
+  return add3(
+    add3(scale3(vector, cosTheta), scale3(cross3(k, vector), sinTheta)),
+    parallel,
+  );
+}
+
+function rotatePointAroundAxis(
+  point: NormalizedVec3,
+  axisOrigin: NormalizedVec3,
+  axis: NormalizedVec3,
+  angle: number,
+): NormalizedVec3 {
+  const relative = sub3(point, axisOrigin);
+  return add3(
+    axisOrigin,
+    rotateVectorAroundAxis(relative, axis, angle),
+  );
+}
+
+function getPlacementBasis(placement: NormalizedPlacement3D): {
+  xAxis: Vector3;
+  yAxis: Vector3;
+  zAxis: Vector3;
+} {
+  const xAxis = toIfcMathVector(placement.xAxis);
+  const zAxis = toIfcMathVector(placement.zAxis);
+  const yAxis = Vector3.Cross(zAxis, xAxis).normalize();
+  return { xAxis, yAxis, zAxis };
+}
+
+function localIfcPointToBabylonRelative(
+  point: NormalizedVec3,
+  placement: NormalizedPlacement3D,
+): Vector3 {
+  const { xAxis, yAxis, zAxis } = getPlacementBasis(placement);
+  return ifcToBabylonVector({
+    x: point.x * xAxis.x + point.y * yAxis.x + point.z * zAxis.x,
+    y: point.x * xAxis.y + point.y * yAxis.y + point.z * zAxis.y,
+    z: point.x * xAxis.z + point.y * yAxis.z + point.z * zAxis.z,
+  });
+}
+
+function appendOrientedTriangle(
+  vertices: NormalizedVec3[],
+  indices: number[],
+  i0: number,
+  i1: number,
+  i2: number,
+  expectedNormal: NormalizedVec3,
+): void {
+  const a = vertices[i0];
+  const b = vertices[i1];
+  const c = vertices[i2];
+  const faceNormal = cross3(sub3(b, a), sub3(c, a));
+  if (dot3(faceNormal, expectedNormal) < 0) {
+    indices.push(i0, i2, i1);
+  } else {
+    indices.push(i0, i1, i2);
+  }
+}
+
+function buildProfileTriangulation(profile: NormalizedProfile): {
+  points: NormalizedVec2[];
+  holeIndices: number[];
+  triangleIndices: number[];
+} {
+  const points = [...profile.outerLoop];
+  const holeIndices: number[] = [];
+
+  for (const innerLoop of profile.innerLoops) {
+    holeIndices.push(points.length);
+    points.push(...innerLoop);
+  }
+
+  const flat = points.flatMap((point) => [point.x, point.y]);
+  return {
+    points,
+    holeIndices,
+    triangleIndices: earcut(flat, holeIndices, 2),
+  };
+}
+
+function chooseReferencePoint(
+  profile: NormalizedProfile,
+  axisOrigin: NormalizedVec3,
+  axis: NormalizedVec3,
+): NormalizedVec3 | null {
+  const loops = [profile.outerLoop, ...profile.innerLoops];
+  for (const loop of loops) {
+    for (const point of loop) {
+      const localPoint = vec2ToLocalPoint(point);
+      const relative = sub3(localPoint, axisOrigin);
+      const radial = sub3(relative, scale3(axis, dot3(relative, axis)));
+      if (magnitude3(radial) >= EPSILON) {
+        return localPoint;
+      }
+    }
+  }
+  return null;
+}
+
+function getRevolutionAngles(angle: number): {
+  angles: number[];
+  isClosed: boolean;
+} {
+  const absAngle = Math.abs(angle);
+  const isClosed = absAngle >= Math.PI * 2 - FULL_REVOLUTION_EPSILON;
+  const segmentCount = Math.max(
+    1,
+    Math.ceil((absAngle / (Math.PI * 2)) * FULL_CIRCLE_SEGMENTS),
+  );
+
+  if (isClosed) {
+    return {
+      isClosed: true,
+      angles: Array.from(
+        { length: segmentCount },
+        (_, index) => (angle * index) / segmentCount,
+      ),
+    };
+  }
+
+  return {
+    isClosed: false,
+    angles: Array.from(
+      { length: segmentCount + 1 },
+      (_, index) => (angle * index) / segmentCount,
+    ),
+  };
+}
+
+function appendLoopSideSurfaces(
+  loop: NormalizedVec2[],
+  axisOrigin: NormalizedVec3,
+  axis: NormalizedVec3,
+  angles: number[],
+  isClosed: boolean,
+  vertices: NormalizedVec3[],
+  indices: number[],
+): void {
+  const ringSpanCount = isClosed ? angles.length : angles.length - 1;
+  const closedStep =
+    isClosed && angles.length > 1
+      ? angles[1] - angles[0]
+      : Math.PI * 2;
+
+  for (let pointIndex = 0; pointIndex < loop.length; pointIndex++) {
+    const nextPointIndex = (pointIndex + 1) % loop.length;
+    const currentPoint = vec2ToLocalPoint(loop[pointIndex]);
+    const nextPoint = vec2ToLocalPoint(loop[nextPointIndex]);
+    const edge = sub3(nextPoint, currentPoint);
+    const outward = normalize3(
+      { x: edge.y, y: -edge.x, z: 0 },
+      { x: 1, y: 0, z: 0 },
+    );
+
+    const stripVertexPairs: Array<[number, number]> = [];
+    for (const theta of angles) {
+      const currentRotated = rotatePointAroundAxis(
+        currentPoint,
+        axisOrigin,
+        axis,
+        theta,
+      );
+      const nextRotated = rotatePointAroundAxis(
+        nextPoint,
+        axisOrigin,
+        axis,
+        theta,
+      );
+      stripVertexPairs.push([
+        vertices.push(currentRotated) - 1,
+        vertices.push(nextRotated) - 1,
+      ]);
+    }
+
+    for (let ringIndex = 0; ringIndex < ringSpanCount; ringIndex++) {
+      const nextRingIndex = (ringIndex + 1) % angles.length;
+      const [i0, i1] = stripVertexPairs[ringIndex];
+      const [i3, i2] = stripVertexPairs[nextRingIndex];
+      const nextAngle =
+        isClosed && nextRingIndex === 0
+          ? angles[ringIndex] + closedStep
+          : angles[nextRingIndex];
+      const midAngle = (angles[ringIndex] + nextAngle) / 2;
+      const expectedNormal = rotateVectorAroundAxis(outward, axis, midAngle);
+
+      appendOrientedTriangle(vertices, indices, i0, i1, i2, expectedNormal);
+      appendOrientedTriangle(vertices, indices, i0, i2, i3, expectedNormal);
+    }
+  }
+}
+
+function appendCapSurfaces(
+  profile: NormalizedProfile,
+  axisOrigin: NormalizedVec3,
+  axis: NormalizedVec3,
+  angle: number,
+  vertices: NormalizedVec3[],
+  indices: number[],
+): void {
+  const referencePoint = chooseReferencePoint(profile, axisOrigin, axis);
+  if (!referencePoint) return;
+
+  const radial = sub3(referencePoint, axisOrigin);
+  const tangent = normalize3(cross3(axis, radial), { x: 1, y: 0, z: 0 });
+  const directionSign = angle < 0 ? -1 : 1;
+  const triangulation = buildProfileTriangulation(profile);
+
+  const startBaseIndex = vertices.length;
+  for (const point of triangulation.points) {
+    vertices.push(vec2ToLocalPoint(point));
+  }
+  const startExpectedNormal = scale3(tangent, -directionSign);
+  for (let i = 0; i < triangulation.triangleIndices.length; i += 3) {
+    appendOrientedTriangle(
+      vertices,
+      indices,
+      startBaseIndex + triangulation.triangleIndices[i],
+      startBaseIndex + triangulation.triangleIndices[i + 1],
+      startBaseIndex + triangulation.triangleIndices[i + 2],
+      startExpectedNormal,
+    );
+  }
+
+  const endBaseIndex = vertices.length;
+  for (const point of triangulation.points) {
+    vertices.push(
+      rotatePointAroundAxis(
+        vec2ToLocalPoint(point),
+        axisOrigin,
+        axis,
+        angle,
+      ),
+    );
+  }
+  const endExpectedNormal = scale3(
+    rotateVectorAroundAxis(tangent, axis, angle),
+    directionSign,
+  );
+  for (let i = 0; i < triangulation.triangleIndices.length; i += 3) {
+    appendOrientedTriangle(
+      vertices,
+      indices,
+      endBaseIndex + triangulation.triangleIndices[i],
+      endBaseIndex + triangulation.triangleIndices[i + 1],
+      endBaseIndex + triangulation.triangleIndices[i + 2],
+      endExpectedNormal,
+    );
+  }
+}
+
+export function buildRevolvedAreaSolidMeshFromNormalized(
+  scene: Scene,
+  revolution: NormalizedRevolution,
+  material: StandardMaterial,
+  name: string,
+): Mesh {
+  const vertices: NormalizedVec3[] = [];
+  const indices: number[] = [];
+  const { profile, placement, axis, angle } = revolution;
+  const { angles, isClosed } = getRevolutionAngles(angle);
+
+  appendLoopSideSurfaces(
+    profile.outerLoop,
+    axis.origin,
+    axis.axis,
+    angles,
+    isClosed,
+    vertices,
+    indices,
+  );
+
+  for (const innerLoop of profile.innerLoops) {
+    appendLoopSideSurfaces(
+      innerLoop,
+      axis.origin,
+      axis.axis,
+      angles,
+      isClosed,
+      vertices,
+      indices,
+    );
+  }
+
+  if (!isClosed) {
+    appendCapSurfaces(profile, axis.origin, axis.axis, angle, vertices, indices);
+  }
+
+  const positions = vertices.flatMap((point) => {
+    const transformed = localIfcPointToBabylonRelative(point, placement);
+    return [transformed.x, transformed.y, transformed.z];
+  });
+
+  const normals = new Array<number>(positions.length).fill(0);
+  VertexData.ComputeNormals(positions, indices, normals, {
+    useRightHandedSystem: scene.useRightHandedSystem,
+  });
+
+  const mesh = new Mesh(name, scene);
+  mesh.setVerticesData(VertexBuffer.PositionKind, positions, false);
+  mesh.setVerticesData(VertexBuffer.NormalKind, normals, false);
+  mesh.setIndices(indices);
+  mesh.position = ifcToBabylonVector(placement.origin);
+  mesh.material = material;
+  return mesh;
+}
+
+export function buildRevolvedAreaSolidMesh(
+  scene: Scene,
+  solid: IfcGeneratedRevolvedAreaSolid,
+  material: StandardMaterial,
+  name: string,
+): Mesh {
+  return buildRevolvedAreaSolidMeshFromNormalized(
+    scene,
+    normalizeRevolvedAreaSolid(solid),
+    material,
+    name,
+  );
+}

--- a/src/ifc/samples/revolved.rectangle.ts
+++ b/src/ifc/samples/revolved.rectangle.ts
@@ -27,6 +27,7 @@ const DEFAULT_PROFILE: IfcProfileDef = {
 const DEFAULT_AXIS_DIRECTION: Vec3 = { x: 0, y: 1, z: 0 };
 const DEFAULT_AXIS_ORIGIN: Vec3 = { x: 2.4, y: 0, z: 0 };
 const DEFAULT_ANGLE_DEG = 120;
+const AXIS_OVERLAY_LENGTH = 8;
 const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
   type: "IfcAxis2Placement3D",
   location: { x: 0, y: 0, z: 0 },
@@ -162,11 +163,6 @@ export const revolvedRectangleSample: SampleDef = {
       y: getNumber(params, "axisDirY"),
       z: 0,
     });
-    const axisLength = Math.max(
-      5,
-      Math.hypot(axisOrigin.x, axisOrigin.y, axisOrigin.z) * 2 +
-        Math.max(rectangleProfile.xDim, rectangleProfile.yDim) * 3,
-    );
 
     const generatedSolid: IfcRevolvedAreaSolid = {
       type: "IfcRevolvedAreaSolid",
@@ -239,12 +235,12 @@ export const revolvedRectangleSample: SampleDef = {
       const axisOverlay = buildRevolutionAxisOverlay(
         scene,
         {
-          x: axisOrigin.x - axisDirection.x * axisLength * 0.5,
-          y: axisOrigin.y - axisDirection.y * axisLength * 0.5,
-          z: axisOrigin.z - axisDirection.z * axisLength * 0.5,
+          x: axisOrigin.x - axisDirection.x * AXIS_OVERLAY_LENGTH * 0.5,
+          y: axisOrigin.y - axisDirection.y * AXIS_OVERLAY_LENGTH * 0.5,
+          z: axisOrigin.z - axisDirection.z * AXIS_OVERLAY_LENGTH * 0.5,
         },
         axisDirection,
-        axisLength,
+        AXIS_OVERLAY_LENGTH,
         "revolved_axis",
         activePlacement,
       );

--- a/src/ifc/samples/revolved.rectangle.ts
+++ b/src/ifc/samples/revolved.rectangle.ts
@@ -27,6 +27,12 @@ const DEFAULT_PROFILE: IfcProfileDef = {
 const DEFAULT_AXIS_DIRECTION: Vec3 = { x: 0, y: 1, z: 0 };
 const DEFAULT_AXIS_ORIGIN: Vec3 = { x: 2.4, y: 0, z: 0 };
 const DEFAULT_ANGLE_DEG = 270;
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
 
 function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180;
@@ -124,6 +130,9 @@ export const revolvedRectangleSample: SampleDef = {
     allowedTypes: ["rectangle"],
     defaultProfile: DEFAULT_PROFILE,
   },
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
   buildGeometry: (
     scene: Scene,
     params: ParamValues,
@@ -131,11 +140,12 @@ export const revolvedRectangleSample: SampleDef = {
     profile?: IfcProfileDef,
     _path?: Vec3[],
     _extrusion?: ExtrusionParams,
-    _placement?: IfcAxis2Placement3D,
+    placement?: IfcAxis2Placement3D,
     _sweepView?: SweepViewState,
   ): Mesh[] => {
     const meshes: Mesh[] = [];
     const activeProfile = profile ?? DEFAULT_PROFILE;
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
     const rectangleProfile =
       activeProfile.type === "IfcRectangleProfileDef"
         ? activeProfile
@@ -170,16 +180,36 @@ export const revolvedRectangleSample: SampleDef = {
         type: "IfcAxis2Placement3D",
         location: {
           type: "IfcCartesianPoint",
-          coordinates: [0, 0, 0],
+          coordinates: [
+            activePlacement.location.x,
+            activePlacement.location.y,
+            activePlacement.location.z,
+          ],
         },
-        axis: {
-          type: "IfcDirection",
-          directionRatios: [0, 0, 1],
-        },
-        refDirection: {
-          type: "IfcDirection",
-          directionRatios: [1, 0, 0],
-        },
+        ...(activePlacement.axis
+          ? {
+              axis: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.axis.x,
+                  activePlacement.axis.y,
+                  activePlacement.axis.z,
+                ],
+              },
+            }
+          : {}),
+        ...(activePlacement.refDirection
+          ? {
+              refDirection: {
+                type: "IfcDirection",
+                directionRatios: [
+                  activePlacement.refDirection.x,
+                  activePlacement.refDirection.y,
+                  activePlacement.refDirection.z,
+                ],
+              },
+            }
+          : {}),
       },
       axis: {
         type: "IfcAxis1Placement",
@@ -216,11 +246,12 @@ export const revolvedRectangleSample: SampleDef = {
         axisDirection,
         axisLength,
         "revolved_axis",
+        activePlacement,
       );
       if (axisOverlay) meshes.push(axisOverlay);
     }
 
-    if (stepIndex >= 2) {
+    if (stepIndex >= 3) {
       meshes.push(
         buildRevolvedAreaSolidMesh(
           scene,
@@ -243,9 +274,9 @@ export const revolvedRectangleSample: SampleDef = {
     },
     position: {
       type: "IfcAxis2Placement3D",
-      location: { type: "IfcCartesianPoint", coordinates: [0, 0, 0] },
-      axis: { type: "IfcDirection", directionRatios: [0, 0, 1] },
-      refDirection: { type: "IfcDirection", directionRatios: [1, 0, 0] },
+      location: "(see placement editor)",
+      axis: "(see placement editor)",
+      refDirection: "(see placement editor)",
     },
     axis: {
       type: "IfcAxis1Placement",

--- a/src/ifc/samples/revolved.rectangle.ts
+++ b/src/ifc/samples/revolved.rectangle.ts
@@ -26,7 +26,7 @@ const DEFAULT_PROFILE: IfcProfileDef = {
 
 const DEFAULT_AXIS_DIRECTION: Vec3 = { x: 0, y: 1, z: 0 };
 const DEFAULT_AXIS_ORIGIN: Vec3 = { x: 2.4, y: 0, z: 0 };
-const DEFAULT_ANGLE_DEG = 270;
+const DEFAULT_ANGLE_DEG = 120;
 const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
   type: "IfcAxis2Placement3D",
   location: { x: 0, y: 0, z: 0 },
@@ -57,15 +57,6 @@ export const revolvedRectangleSample: SampleDef = {
     "A rectangular area profile revolved around a configurable local axis. " +
     "The axis origin and direction stay in the local XY plane, matching the IFC constraints for IfcRevolvedAreaSolid.",
   parameters: [
-    {
-      key: "angleDeg",
-      label: "Angle (deg)",
-      type: "number",
-      min: 15,
-      max: 360,
-      step: 5,
-      defaultValue: DEFAULT_ANGLE_DEG,
-    },
     {
       key: "axisOriginX",
       label: "Axis Origin X",
@@ -101,6 +92,15 @@ export const revolvedRectangleSample: SampleDef = {
       max: 1,
       step: 0.1,
       defaultValue: DEFAULT_AXIS_DIRECTION.y,
+    },
+    {
+      key: "angleDeg",
+      label: "Angle (deg)",
+      type: "number",
+      min: 15,
+      max: 360,
+      step: 5,
+      defaultValue: DEFAULT_ANGLE_DEG,
     },
   ],
   steps: [
@@ -251,7 +251,7 @@ export const revolvedRectangleSample: SampleDef = {
       if (axisOverlay) meshes.push(axisOverlay);
     }
 
-    if (stepIndex >= 3) {
+    if (stepIndex >= 2) {
       meshes.push(
         buildRevolvedAreaSolidMesh(
           scene,

--- a/src/ifc/samples/revolved.rectangle.ts
+++ b/src/ifc/samples/revolved.rectangle.ts
@@ -1,0 +1,207 @@
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  SampleDef,
+  ParamValues,
+  IfcProfileDef,
+  Vec3,
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  SweepViewState,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { createExtrusionMaterial } from "../../engine/materials.ts";
+import {
+  buildProfileOverlay,
+  buildRevolutionAxisOverlay,
+} from "../../engine/overlays.ts";
+import { buildRevolvedAreaSolidMesh } from "../operations/revolution.ts";
+import type { IfcRevolvedAreaSolid } from "../generated/schema.ts";
+
+const DEFAULT_PROFILE: IfcProfileDef = {
+  type: "IfcRectangleProfileDef",
+  profileType: "AREA",
+  xDim: 1.6,
+  yDim: 0.8,
+};
+
+const DEFAULT_AXIS_DIRECTION: Vec3 = { x: 0, y: 1, z: 0 };
+const DEFAULT_AXIS_OFFSET_X = 2.4;
+const DEFAULT_ANGLE_DEG = 270;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+export const revolvedRectangleSample: SampleDef = {
+  id: "revolved-rectangle",
+  title: "Revolved Area Solid (IfcRevolvedAreaSolid)",
+  description:
+    "A rectangular area profile revolved around an offset local axis. " +
+    "Use the angle slider to compare open revolutions with a closed 360° solid.",
+  parameters: [
+    {
+      key: "angleDeg",
+      label: "Angle (deg)",
+      type: "number",
+      min: 15,
+      max: 360,
+      step: 5,
+      defaultValue: DEFAULT_ANGLE_DEG,
+    },
+    {
+      key: "axisOffsetX",
+      label: "Axis Offset X",
+      type: "number",
+      min: 1,
+      max: 5,
+      step: 0.1,
+      defaultValue: DEFAULT_AXIS_OFFSET_X,
+    },
+  ],
+  steps: [
+    {
+      id: "profile",
+      label: "Step 1: Area Profile",
+      description:
+        "IfcRevolvedAreaSolid starts from a planar swept area. " +
+        "This sample uses an IfcRectangleProfileDef as the section to rotate.",
+    },
+    {
+      id: "axis",
+      label: "Step 2: Revolution Axis",
+      description:
+        "IfcAxis1Placement defines the axis origin and direction in the solid's local coordinate system. " +
+        "Here the axis runs along local Y and is offset from the profile.",
+    },
+    {
+      id: "solid",
+      label: "Step 3: Revolved Solid",
+      description:
+        "The profile is rotated around the axis by the given angle to create the final solid. " +
+        "Angles below 360° keep start/end caps; 360° closes the seam into a full revolution.",
+    },
+  ],
+  profileEditorConfig: {
+    allowedTypes: ["rectangle"],
+    defaultProfile: DEFAULT_PROFILE,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const meshes: Mesh[] = [];
+    const activeProfile = profile ?? DEFAULT_PROFILE;
+    const rectangleProfile =
+      activeProfile.type === "IfcRectangleProfileDef"
+        ? activeProfile
+        : DEFAULT_PROFILE;
+
+    const angleDeg = getNumber(params, "angleDeg");
+    const axisOffsetX = getNumber(params, "axisOffsetX");
+    const axisLength = Math.max(5, axisOffsetX * 2 + rectangleProfile.yDim * 2);
+
+    const generatedSolid: IfcRevolvedAreaSolid = {
+      type: "IfcRevolvedAreaSolid",
+      sweptArea: {
+        type: "IfcRectangleProfileDef",
+        profileType: "AREA",
+        xDim: rectangleProfile.xDim,
+        yDim: rectangleProfile.yDim,
+      },
+      position: {
+        type: "IfcAxis2Placement3D",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [0, 0, 0],
+        },
+        axis: {
+          type: "IfcDirection",
+          directionRatios: [0, 0, 1],
+        },
+        refDirection: {
+          type: "IfcDirection",
+          directionRatios: [1, 0, 0],
+        },
+      },
+      axis: {
+        type: "IfcAxis1Placement",
+        location: {
+          type: "IfcCartesianPoint",
+          coordinates: [axisOffsetX, 0, 0],
+        },
+        axis: {
+          type: "IfcDirection",
+          directionRatios: [
+            DEFAULT_AXIS_DIRECTION.x,
+            DEFAULT_AXIS_DIRECTION.y,
+            DEFAULT_AXIS_DIRECTION.z,
+          ],
+        },
+      },
+      angle: toRadians(angleDeg),
+    };
+
+    if (stepIndex >= 0) {
+      meshes.push(
+        ...buildProfileOverlay(scene, rectangleProfile, "revolved_rectangle_outline"),
+      );
+    }
+
+    if (stepIndex >= 1) {
+      const axisOverlay = buildRevolutionAxisOverlay(
+        scene,
+        { x: axisOffsetX, y: -axisLength / 2, z: 0 },
+        DEFAULT_AXIS_DIRECTION,
+        axisLength,
+        "revolved_axis",
+      );
+      if (axisOverlay) meshes.push(axisOverlay);
+    }
+
+    if (stepIndex >= 2) {
+      meshes.push(
+        buildRevolvedAreaSolidMesh(
+          scene,
+          generatedSolid,
+          createExtrusionMaterial(scene),
+          "revolved_solid",
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (params: ParamValues) => ({
+    type: "IfcRevolvedAreaSolid",
+    sweptArea: {
+      type: "IfcRectangleProfileDef",
+      profileType: "AREA",
+      xDim: "(see profile editor)",
+      yDim: "(see profile editor)",
+    },
+    position: {
+      type: "IfcAxis2Placement3D",
+      location: { type: "IfcCartesianPoint", coordinates: [0, 0, 0] },
+      axis: { type: "IfcDirection", directionRatios: [0, 0, 1] },
+      refDirection: { type: "IfcDirection", directionRatios: [1, 0, 0] },
+    },
+    axis: {
+      type: "IfcAxis1Placement",
+      location: {
+        type: "IfcCartesianPoint",
+        coordinates: [getNumber(params, "axisOffsetX"), 0, 0],
+      },
+      axis: {
+        type: "IfcDirection",
+        directionRatios: [0, 1, 0],
+      },
+    },
+    angle: Number(toRadians(getNumber(params, "angleDeg")).toFixed(4)),
+  }),
+};

--- a/src/ifc/samples/revolved.rectangle.ts
+++ b/src/ifc/samples/revolved.rectangle.ts
@@ -25,19 +25,31 @@ const DEFAULT_PROFILE: IfcProfileDef = {
 };
 
 const DEFAULT_AXIS_DIRECTION: Vec3 = { x: 0, y: 1, z: 0 };
-const DEFAULT_AXIS_OFFSET_X = 2.4;
+const DEFAULT_AXIS_ORIGIN: Vec3 = { x: 2.4, y: 0, z: 0 };
 const DEFAULT_ANGLE_DEG = 270;
 
 function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180;
 }
 
+function normalizeDirection(direction: Vec3): Vec3 {
+  const length = Math.hypot(direction.x, direction.y, direction.z);
+  if (length < 1e-9) {
+    return DEFAULT_AXIS_DIRECTION;
+  }
+  return {
+    x: direction.x / length,
+    y: direction.y / length,
+    z: direction.z / length,
+  };
+}
+
 export const revolvedRectangleSample: SampleDef = {
   id: "revolved-rectangle",
   title: "Revolved Area Solid (IfcRevolvedAreaSolid)",
   description:
-    "A rectangular area profile revolved around an offset local axis. " +
-    "Use the angle slider to compare open revolutions with a closed 360° solid.",
+    "A rectangular area profile revolved around a configurable local axis. " +
+    "The axis origin and direction stay in the local XY plane, matching the IFC constraints for IfcRevolvedAreaSolid.",
   parameters: [
     {
       key: "angleDeg",
@@ -49,13 +61,40 @@ export const revolvedRectangleSample: SampleDef = {
       defaultValue: DEFAULT_ANGLE_DEG,
     },
     {
-      key: "axisOffsetX",
-      label: "Axis Offset X",
+      key: "axisOriginX",
+      label: "Axis Origin X",
       type: "number",
-      min: 1,
+      min: -5,
       max: 5,
       step: 0.1,
-      defaultValue: DEFAULT_AXIS_OFFSET_X,
+      defaultValue: DEFAULT_AXIS_ORIGIN.x,
+    },
+    {
+      key: "axisOriginY",
+      label: "Axis Origin Y",
+      type: "number",
+      min: -5,
+      max: 5,
+      step: 0.1,
+      defaultValue: DEFAULT_AXIS_ORIGIN.y,
+    },
+    {
+      key: "axisDirX",
+      label: "Axis Dir X",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.1,
+      defaultValue: DEFAULT_AXIS_DIRECTION.x,
+    },
+    {
+      key: "axisDirY",
+      label: "Axis Dir Y",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.1,
+      defaultValue: DEFAULT_AXIS_DIRECTION.y,
     },
   ],
   steps: [
@@ -71,7 +110,7 @@ export const revolvedRectangleSample: SampleDef = {
       label: "Step 2: Revolution Axis",
       description:
         "IfcAxis1Placement defines the axis origin and direction in the solid's local coordinate system. " +
-        "Here the axis runs along local Y and is offset from the profile.",
+        "For IfcRevolvedAreaSolid, both the axis start point and direction must stay in the local XY plane.",
     },
     {
       id: "solid",
@@ -103,8 +142,21 @@ export const revolvedRectangleSample: SampleDef = {
         : DEFAULT_PROFILE;
 
     const angleDeg = getNumber(params, "angleDeg");
-    const axisOffsetX = getNumber(params, "axisOffsetX");
-    const axisLength = Math.max(5, axisOffsetX * 2 + rectangleProfile.yDim * 2);
+    const axisOrigin = {
+      x: getNumber(params, "axisOriginX"),
+      y: getNumber(params, "axisOriginY"),
+      z: 0,
+    };
+    const axisDirection = normalizeDirection({
+      x: getNumber(params, "axisDirX"),
+      y: getNumber(params, "axisDirY"),
+      z: 0,
+    });
+    const axisLength = Math.max(
+      5,
+      Math.hypot(axisOrigin.x, axisOrigin.y, axisOrigin.z) * 2 +
+        Math.max(rectangleProfile.xDim, rectangleProfile.yDim) * 3,
+    );
 
     const generatedSolid: IfcRevolvedAreaSolid = {
       type: "IfcRevolvedAreaSolid",
@@ -133,14 +185,14 @@ export const revolvedRectangleSample: SampleDef = {
         type: "IfcAxis1Placement",
         location: {
           type: "IfcCartesianPoint",
-          coordinates: [axisOffsetX, 0, 0],
+          coordinates: [axisOrigin.x, axisOrigin.y, axisOrigin.z],
         },
         axis: {
           type: "IfcDirection",
           directionRatios: [
-            DEFAULT_AXIS_DIRECTION.x,
-            DEFAULT_AXIS_DIRECTION.y,
-            DEFAULT_AXIS_DIRECTION.z,
+            axisDirection.x,
+            axisDirection.y,
+            axisDirection.z,
           ],
         },
       },
@@ -156,8 +208,12 @@ export const revolvedRectangleSample: SampleDef = {
     if (stepIndex >= 1) {
       const axisOverlay = buildRevolutionAxisOverlay(
         scene,
-        { x: axisOffsetX, y: -axisLength / 2, z: 0 },
-        DEFAULT_AXIS_DIRECTION,
+        {
+          x: axisOrigin.x - axisDirection.x * axisLength * 0.5,
+          y: axisOrigin.y - axisDirection.y * axisLength * 0.5,
+          z: axisOrigin.z - axisDirection.z * axisLength * 0.5,
+        },
+        axisDirection,
         axisLength,
         "revolved_axis",
       );
@@ -195,11 +251,27 @@ export const revolvedRectangleSample: SampleDef = {
       type: "IfcAxis1Placement",
       location: {
         type: "IfcCartesianPoint",
-        coordinates: [getNumber(params, "axisOffsetX"), 0, 0],
+        coordinates: [
+          getNumber(params, "axisOriginX"),
+          getNumber(params, "axisOriginY"),
+          0,
+        ],
       },
       axis: {
         type: "IfcDirection",
-        directionRatios: [0, 1, 0],
+        directionRatios: [
+          Number(normalizeDirection({
+            x: getNumber(params, "axisDirX"),
+            y: getNumber(params, "axisDirY"),
+            z: 0,
+          }).x.toFixed(4)),
+          Number(normalizeDirection({
+            x: getNumber(params, "axisDirX"),
+            y: getNumber(params, "axisDirY"),
+            z: 0,
+          }).y.toFixed(4)),
+          0,
+        ],
       },
     },
     angle: Number(toRadians(getNumber(params, "angleDeg")).toFixed(4)),

--- a/src/pages/ExamplePage.ts
+++ b/src/pages/ExamplePage.ts
@@ -129,16 +129,6 @@ export class ExamplePage {
                 : ""
             }
             ${
-              hasPlacementEditor
-                ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor ? " left-panel-section-mt" : ""}">
-                <summary class="params-title">${sample.placementEditorConfig!.label ?? "Placement"}</summary>
-                <div class="left-collapsible-content" id="placement-editor-panel"></div>
-              </details>
-            `
-                : ""
-            }
-            ${
               hasSweepToggles
                 ? `
               <details class="left-collapsible left-panel-section-mt" open>
@@ -151,9 +141,19 @@ export class ExamplePage {
             ${
               sample.parameters.length > 0
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor || hasPlacementEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">Parameters</summary>
                 <div class="left-collapsible-content" id="param-panel"></div>
+              </details>
+            `
+                : ""
+            }
+            ${
+              hasPlacementEditor
+                ? `
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
+                <summary class="params-title">${sample.placementEditorConfig!.label ?? "Placement"}</summary>
+                <div class="left-collapsible-content" id="placement-editor-panel"></div>
               </details>
             `
                 : ""


### PR DESCRIPTION
## Summary
- implement `IfcRevolvedAreaSolid` mesh generation and normalization
- add a new revolved rectangle sample with axis/angle controls and axis overlay
- wire the sample into the app routes and adjust the example page panel order for the new controls

## Why
This adds interactive support for revolved area solids in the playground so we can inspect the geometry, local-axis constraints, and partial-vs-full revolution behavior from the UI.

## Impact
- users can open a working `Revolved Area Solid` example instead of a planned placeholder
- the renderer now supports revolution-based solid generation from the generated IFC schema
- the sample visualizes the local revolution axis and enforces the IFC local-XY-plane constraints for the axis origin and direction

## Validation
- `bun run build`
