### PR TITLE
[codex] Redesign home around implementation map

### DIFF
--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -14,6 +14,7 @@ export const GEOMETRY_DOMAINS: GeometryDomain[] = [
 export type Difficulty = "beginner" | "intermediate" | "advanced";
 export type ExampleKind = "primary" | "variant";
 export type ImplementationStatus = "available" | "partial" | "planned";
+export type OperationGroupId = "extrusion" | "revolution" | "swept-disk";
 
 interface BaseRoute {
   hash: string;
@@ -29,6 +30,7 @@ export interface StaticRoute extends BaseRoute {
   status?: undefined;
   entity?: undefined;
   dependsOn?: undefined;
+  operationGroup?: undefined;
 }
 
 export interface AvailableRoute extends BaseRoute {
@@ -40,6 +42,7 @@ export interface AvailableRoute extends BaseRoute {
   status: "available";
   entity: string;
   dependsOn?: string[];
+  operationGroup?: OperationGroupId;
 }
 
 export interface PlannedRoute extends BaseRoute {
@@ -51,6 +54,7 @@ export interface PlannedRoute extends BaseRoute {
   status: "planned";
   entity: string;
   dependsOn?: string[];
+  operationGroup?: undefined;
 }
 
 export type Route = StaticRoute | AvailableRoute | PlannedRoute;
@@ -63,6 +67,41 @@ export interface ImplementationMapItem {
   routeHash?: string;
   dependsOn?: string[];
 }
+
+export interface OperationGroup {
+  id: OperationGroupId;
+  domain: GeometryDomain;
+  title: string;
+  entity: string;
+  description: string;
+}
+
+export const OPERATION_GROUPS: OperationGroup[] = [
+  {
+    id: "extrusion",
+    domain: "Swept Solids",
+    title: "Extrusion",
+    entity: "IfcExtrudedAreaSolid",
+    description:
+      "Sweep area profiles along an extrusion direction and compare profile-specific variants.",
+  },
+  {
+    id: "revolution",
+    domain: "Swept Solids",
+    title: "Revolution",
+    entity: "IfcRevolvedAreaSolid",
+    description:
+      "Rotate an area profile around a local axis to create a revolved solid.",
+  },
+  {
+    id: "swept-disk",
+    domain: "Swept Solids",
+    title: "Swept Disk",
+    entity: "IfcSweptDiskSolid",
+    description:
+      "Sweep a disk or ring along a curve directrix.",
+  },
+];
 
 export const routes: Route[] = [
   { hash: "#/", title: "Home" },
@@ -90,42 +129,45 @@ export const routes: Route[] = [
   },
   {
     hash: "#/examples/extrusion-rectangle",
-    title: "Extrusion",
+    title: "Rectangle",
     description:
-      "Build a swept solid from an area profile and an extrusion direction (IfcExtrudedAreaSolid).",
+      "Extrude an IfcRectangleProfileDef along an extrusion direction.",
     sampleId: "extrusion-rectangle",
     domain: "Swept Solids",
     difficulty: "beginner",
-    exampleKind: "primary",
+    exampleKind: "variant",
     status: "available",
-    entity: "IfcExtrudedAreaSolid",
-    dependsOn: ["IfcProfileDef"],
+    entity: "IfcRectangleProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/revolved",
-    title: "Revolution",
+    title: "Rectangle",
     description:
-      "Rotate an area profile around a local axis to create a revolved solid (IfcRevolvedAreaSolid).",
+      "Revolve an IfcRectangleProfileDef around a local axis.",
     sampleId: "revolved-rectangle",
     domain: "Swept Solids",
     difficulty: "intermediate",
-    exampleKind: "primary",
+    exampleKind: "variant",
     status: "available",
-    entity: "IfcRevolvedAreaSolid",
-    dependsOn: ["IfcProfileDef"],
+    entity: "IfcRectangleProfileDef",
+    dependsOn: ["IfcRevolvedAreaSolid"],
+    operationGroup: "revolution",
   },
   {
     hash: "#/examples/swept-disk",
-    title: "Swept Disk",
+    title: "Polyline Directrix",
     description:
-      "Sweep a circular disk or pipe section along a curve-based path (IfcSweptDiskSolid).",
+      "Sweep a circular disk or pipe section along an IfcPolyline directrix.",
     sampleId: "swept-disk-basic",
     domain: "Swept Solids",
     difficulty: "intermediate",
-    exampleKind: "primary",
+    exampleKind: "variant",
     status: "available",
-    entity: "IfcSweptDiskSolid",
-    dependsOn: ["IfcCurve"],
+    entity: "IfcPolyline",
+    dependsOn: ["IfcSweptDiskSolid"],
+    operationGroup: "swept-disk",
   },
   {
     hash: "#/examples/fixed-reference-sweep",
@@ -157,12 +199,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcRoundedRectangleProfileDef within the extrusion workflow.",
     sampleId: "extrusion-rounded-rectangle",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcRoundedRectangleProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-circle",
@@ -170,12 +213,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcCircleProfileDef within the extrusion workflow.",
     sampleId: "extrusion-circle",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcCircleProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-ellipse",
@@ -183,12 +227,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcEllipseProfileDef within the extrusion workflow.",
     sampleId: "extrusion-ellipse",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcEllipseProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-rect-hollow",
@@ -196,12 +241,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcRectangleHollowProfileDef within the extrusion workflow.",
     sampleId: "extrusion-rect-hollow",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcRectangleHollowProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-circle-hollow",
@@ -209,12 +255,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcCircleHollowProfileDef within the extrusion workflow.",
     sampleId: "extrusion-circle-hollow",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcCircleHollowProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-i-shape",
@@ -222,12 +269,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcIShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-i-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcIShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-asymmetric-i-shape",
@@ -235,12 +283,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcAsymmetricIShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-asymmetric-i-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "intermediate",
     exampleKind: "variant",
     status: "available",
     entity: "IfcAsymmetricIShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-c-shape",
@@ -248,12 +297,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcCShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-c-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcCShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-l-shape",
@@ -261,12 +311,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcLShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-l-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcLShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-t-shape",
@@ -274,12 +325,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcTShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-t-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcTShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-u-shape",
@@ -287,12 +339,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcUShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-u-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcUShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/extrusion-z-shape",
@@ -300,12 +353,13 @@ export const routes: Route[] = [
     description:
       "Implemented variant for IfcZShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-z-shape",
-    domain: "Profiles",
+    domain: "Swept Solids",
     difficulty: "beginner",
     exampleKind: "variant",
     status: "available",
     entity: "IfcZShapeProfileDef",
     dependsOn: ["IfcExtrudedAreaSolid"],
+    operationGroup: "extrusion",
   },
   {
     hash: "#/examples/boolean",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,16 +1,19 @@
-export type HomeSection =
-  | "Foundations"
-  | "Build Solids"
-  | "Compose Solids";
+export type GeometryDomain =
+  | "Curves"
+  | "Profiles"
+  | "Swept Solids"
+  | "Boolean / CSG";
 
-export const HOME_SECTIONS: HomeSection[] = [
-  "Foundations",
-  "Build Solids",
-  "Compose Solids",
+export const GEOMETRY_DOMAINS: GeometryDomain[] = [
+  "Curves",
+  "Profiles",
+  "Swept Solids",
+  "Boolean / CSG",
 ];
 
 export type Difficulty = "beginner" | "intermediate" | "advanced";
-export type HomeKind = "featured" | "coverage";
+export type ExampleKind = "primary" | "variant";
+export type ImplementationStatus = "available" | "partial" | "planned";
 
 interface BaseRoute {
   hash: string;
@@ -20,31 +23,46 @@ interface BaseRoute {
 
 export interface StaticRoute extends BaseRoute {
   sampleId?: undefined;
-  homeSection?: undefined;
+  domain?: undefined;
   difficulty?: undefined;
-  homeKind?: undefined;
+  exampleKind?: undefined;
   status?: undefined;
+  entity?: undefined;
+  dependsOn?: undefined;
 }
 
 export interface AvailableRoute extends BaseRoute {
   description: string;
   sampleId: string;
-  homeSection: HomeSection;
+  domain: GeometryDomain;
   difficulty: Difficulty;
-  homeKind: HomeKind;
+  exampleKind: ExampleKind;
   status: "available";
+  entity: string;
+  dependsOn?: string[];
 }
 
 export interface PlannedRoute extends BaseRoute {
   description: string;
   sampleId?: undefined;
-  homeSection: HomeSection;
+  domain: GeometryDomain;
   difficulty: Difficulty;
-  homeKind: "featured";
+  exampleKind: "primary";
   status: "planned";
+  entity: string;
+  dependsOn?: string[];
 }
 
 export type Route = StaticRoute | AvailableRoute | PlannedRoute;
+
+export interface ImplementationMapItem {
+  entity: string;
+  domain: GeometryDomain;
+  status: ImplementationStatus;
+  description: string;
+  routeHash?: string;
+  dependsOn?: string[];
+}
 
 export const routes: Route[] = [
   { hash: "#/", title: "Home" },
@@ -53,30 +71,22 @@ export const routes: Route[] = [
     title: "Curves",
     description:
       "Explore curve primitives before using them as directrices for sweep-based geometry.",
-    homeSection: "Foundations",
+    domain: "Curves",
     difficulty: "beginner",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
+    entity: "IfcCurve",
   },
   {
     hash: "#/examples/profiles",
     title: "Profiles",
     description:
       "Inspect and compare reusable area profiles before they are turned into solids.",
-    homeSection: "Foundations",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
-  },
-  {
-    hash: "#/examples/placement",
-    title: "Placement",
-    description:
-      "See how local axes and placements affect profile orientation and solid generation.",
-    homeSection: "Foundations",
-    difficulty: "beginner",
-    homeKind: "featured",
-    status: "planned",
+    entity: "IfcProfileDef",
   },
   {
     hash: "#/examples/extrusion-rectangle",
@@ -84,10 +94,12 @@ export const routes: Route[] = [
     description:
       "Build a swept solid from an area profile and an extrusion direction (IfcExtrudedAreaSolid).",
     sampleId: "extrusion-rectangle",
-    homeSection: "Build Solids",
+    domain: "Swept Solids",
     difficulty: "beginner",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "available",
+    entity: "IfcExtrudedAreaSolid",
+    dependsOn: ["IfcProfileDef"],
   },
   {
     hash: "#/examples/revolved",
@@ -95,10 +107,12 @@ export const routes: Route[] = [
     description:
       "Rotate an area profile around a local axis to create a revolved solid (IfcRevolvedAreaSolid).",
     sampleId: "revolved-rectangle",
-    homeSection: "Build Solids",
+    domain: "Swept Solids",
     difficulty: "intermediate",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "available",
+    entity: "IfcRevolvedAreaSolid",
+    dependsOn: ["IfcProfileDef"],
   },
   {
     hash: "#/examples/swept-disk",
@@ -106,162 +120,192 @@ export const routes: Route[] = [
     description:
       "Sweep a circular disk or pipe section along a curve-based path (IfcSweptDiskSolid).",
     sampleId: "swept-disk-basic",
-    homeSection: "Build Solids",
+    domain: "Swept Solids",
     difficulty: "intermediate",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "available",
+    entity: "IfcSweptDiskSolid",
+    dependsOn: ["IfcCurve"],
   },
   {
     hash: "#/examples/fixed-reference-sweep",
     title: "Fixed-Reference Sweep",
     description:
       "Sweep a profile along a curve while controlling the reference orientation (IfcFixedReferenceSweptAreaSolid).",
-    homeSection: "Build Solids",
+    domain: "Swept Solids",
     difficulty: "intermediate",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
+    entity: "IfcFixedReferenceSweptAreaSolid",
+    dependsOn: ["IfcCurve", "IfcProfileDef"],
   },
   {
     hash: "#/examples/sectioned-solid",
     title: "Sectioned Solid",
     description:
       "Interpolate multiple section profiles along a horizontal alignment (IfcSectionedSolidHorizontal).",
-    homeSection: "Build Solids",
+    domain: "Swept Solids",
     difficulty: "advanced",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
+    entity: "IfcSectionedSolidHorizontal",
+    dependsOn: ["IfcCurve", "IfcProfileDef"],
   },
   {
     hash: "#/examples/extrusion-rounded-rectangle",
     title: "Rounded Rectangle",
     description:
-      "Variation coverage for IfcRoundedRectangleProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcRoundedRectangleProfileDef within the extrusion workflow.",
     sampleId: "extrusion-rounded-rectangle",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcRoundedRectangleProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-circle",
     title: "Circle",
     description:
-      "Variation coverage for IfcCircleProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcCircleProfileDef within the extrusion workflow.",
     sampleId: "extrusion-circle",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcCircleProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-ellipse",
     title: "Ellipse",
     description:
-      "Variation coverage for IfcEllipseProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcEllipseProfileDef within the extrusion workflow.",
     sampleId: "extrusion-ellipse",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcEllipseProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-rect-hollow",
     title: "Rectangular Hollow",
     description:
-      "Variation coverage for IfcRectangleHollowProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcRectangleHollowProfileDef within the extrusion workflow.",
     sampleId: "extrusion-rect-hollow",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcRectangleHollowProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-circle-hollow",
     title: "Circular Hollow",
     description:
-      "Variation coverage for IfcCircleHollowProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcCircleHollowProfileDef within the extrusion workflow.",
     sampleId: "extrusion-circle-hollow",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcCircleHollowProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-i-shape",
     title: "I-Shape",
     description:
-      "Variation coverage for IfcIShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcIShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-i-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcIShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-asymmetric-i-shape",
     title: "Asymmetric I-Shape",
     description:
-      "Variation coverage for IfcAsymmetricIShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcAsymmetricIShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-asymmetric-i-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "intermediate",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcAsymmetricIShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-c-shape",
     title: "C-Shape",
     description:
-      "Variation coverage for IfcCShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcCShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-c-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcCShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-l-shape",
     title: "L-Shape",
     description:
-      "Variation coverage for IfcLShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcLShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-l-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcLShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-t-shape",
     title: "T-Shape",
     description:
-      "Variation coverage for IfcTShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcTShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-t-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcTShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-u-shape",
     title: "U-Shape",
     description:
-      "Variation coverage for IfcUShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcUShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-u-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcUShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/extrusion-z-shape",
     title: "Z-Shape",
     description:
-      "Variation coverage for IfcZShapeProfileDef within the extrusion workflow.",
+      "Implemented variant for IfcZShapeProfileDef within the extrusion workflow.",
     sampleId: "extrusion-z-shape",
-    homeSection: "Build Solids",
+    domain: "Profiles",
     difficulty: "beginner",
-    homeKind: "coverage",
+    exampleKind: "variant",
     status: "available",
+    entity: "IfcZShapeProfileDef",
+    dependsOn: ["IfcExtrudedAreaSolid"],
   },
   {
     hash: "#/examples/boolean",
@@ -269,29 +313,133 @@ export const routes: Route[] = [
     description:
       "Combine solids with boolean operations such as difference, union, and intersection (IfcBooleanResult).",
     sampleId: "boolean-difference",
-    homeSection: "Compose Solids",
+    domain: "Boolean / CSG",
     difficulty: "beginner",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "available",
+    entity: "IfcBooleanResult",
   },
   {
     hash: "#/examples/boolean-clipping",
     title: "Half-Space Clipping",
     description:
       "Trim a solid with half-space operands such as IfcHalfSpaceSolid and IfcPolygonalBoundedHalfSpace.",
-    homeSection: "Compose Solids",
+    domain: "Boolean / CSG",
     difficulty: "intermediate",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
+    entity: "IfcHalfSpaceSolid",
   },
   {
     hash: "#/examples/csg-primitives",
     title: "CSG Primitives",
     description:
       "Construct solids from primitive volumes such as block, cylinder, cone, sphere, and rectangular pyramid.",
-    homeSection: "Compose Solids",
+    domain: "Boolean / CSG",
     difficulty: "beginner",
-    homeKind: "featured",
+    exampleKind: "primary",
     status: "planned",
+    entity: "IfcCsgPrimitive3D",
+  },
+];
+
+export const implementationMap: ImplementationMapItem[] = [
+  {
+    entity: "IfcCurve",
+    domain: "Curves",
+    status: "planned",
+    description: "Abstract curve base for directrices and profile boundaries.",
+  },
+  {
+    entity: "IfcPolyline",
+    domain: "Curves",
+    status: "available",
+    description: "Polyline directrix used by the swept disk sample.",
+    routeHash: "#/examples/swept-disk",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcIndexedPolyCurve",
+    domain: "Curves",
+    status: "planned",
+    description: "Indexed curve representation for compact polyline and arc paths.",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcCircle",
+    domain: "Curves",
+    status: "planned",
+    description: "Circle curve primitive for boundaries and path-based operations.",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcEllipse",
+    domain: "Curves",
+    status: "planned",
+    description: "Ellipse curve primitive for boundaries and path-based operations.",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcProfileDef",
+    domain: "Profiles",
+    status: "partial",
+    description: "Area profile family used by extrusion and revolution samples.",
+  },
+  {
+    entity: "IfcExtrudedAreaSolid",
+    domain: "Swept Solids",
+    status: "available",
+    description: "Sweeps an area profile along an extrusion direction.",
+    routeHash: "#/examples/extrusion-rectangle",
+    dependsOn: ["IfcProfileDef"],
+  },
+  {
+    entity: "IfcRevolvedAreaSolid",
+    domain: "Swept Solids",
+    status: "available",
+    description: "Rotates an area profile around a local axis.",
+    routeHash: "#/examples/revolved",
+    dependsOn: ["IfcProfileDef"],
+  },
+  {
+    entity: "IfcSweptDiskSolid",
+    domain: "Swept Solids",
+    status: "available",
+    description: "Sweeps a disk or ring along a curve directrix.",
+    routeHash: "#/examples/swept-disk",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcFixedReferenceSweptAreaSolid",
+    domain: "Swept Solids",
+    status: "planned",
+    description: "Sweeps an area profile along a curve with fixed orientation reference.",
+    dependsOn: ["IfcCurve", "IfcProfileDef"],
+  },
+  {
+    entity: "IfcSectionedSolidHorizontal",
+    domain: "Swept Solids",
+    status: "planned",
+    description: "Interpolates changing section profiles along an alignment.",
+    dependsOn: ["IfcCurve", "IfcProfileDef"],
+  },
+  {
+    entity: "IfcBooleanResult",
+    domain: "Boolean / CSG",
+    status: "available",
+    description: "Combines two operands with boolean set operations.",
+    routeHash: "#/examples/boolean",
+  },
+  {
+    entity: "IfcHalfSpaceSolid",
+    domain: "Boolean / CSG",
+    status: "planned",
+    description: "Trims solids against half-space operands.",
+  },
+  {
+    entity: "IfcCsgPrimitive3D",
+    domain: "Boolean / CSG",
+    status: "planned",
+    description: "Primitive volume family for CSG workflows.",
   },
 ];

--- a/src/pages/HomePage.ts
+++ b/src/pages/HomePage.ts
@@ -2,11 +2,13 @@ import {
   routes,
   GEOMETRY_DOMAINS,
   implementationMap,
+  OPERATION_GROUPS,
 } from "../app/routes.ts";
 import type {
   AvailableRoute,
   Difficulty,
   GeometryDomain,
+  OperationGroup,
   ImplementationStatus,
   PlannedRoute,
   Route,
@@ -28,7 +30,7 @@ const DOMAIN_DESCRIPTIONS: Record<GeometryDomain, string> = {
   Curves:
     "Curve entities used as directrices, path segments, and profile boundaries.",
   Profiles:
-    "Shape-bearing area profiles that can be extruded, revolved, or swept.",
+    "Profile workbench for inspecting reusable area definitions before they are used by operations.",
   "Swept Solids":
     "Operations that turn profiles or curve paths into solids.",
   "Boolean / CSG":
@@ -72,35 +74,69 @@ function renderCard(route: AvailableRoute | PlannedRoute): string {
   `;
 }
 
+function renderOperationGroup(
+  group: OperationGroup,
+  groupRoutes: AvailableRoute[],
+): string {
+  if (groupRoutes.length === 0) return "";
+
+  const variantCards = groupRoutes.map(renderCard).join("");
+
+  return `
+    <div class="operation-group">
+      <div class="operation-header">
+        <div>
+          <h3>${group.title}</h3>
+          <span class="operation-entity">${group.entity}</span>
+        </div>
+        <p>${group.description}</p>
+      </div>
+      <div class="examples-grid examples-grid--variants">
+        ${variantCards}
+      </div>
+    </div>
+  `;
+}
+
 function renderDomain(domain: GeometryDomain, domainRoutes: Route[]): string {
   const routesWithDomain = domainRoutes.filter(hasHomeDomain);
   if (routesWithDomain.length === 0) return "";
 
-  const primaryRoutes = routesWithDomain.filter(
-    (route) => route.exampleKind === "primary",
+  const operationGroups = OPERATION_GROUPS.filter(
+    (group) => group.domain === domain,
   );
-  const variantRoutes = routesWithDomain.filter(
-    (route) => route.exampleKind === "variant",
+
+  const operationGroupMarkup = operationGroups
+    .map((group) =>
+      renderOperationGroup(
+        group,
+        routesWithDomain.filter(
+          (route): route is AvailableRoute =>
+            route.status === "available" && route.operationGroup === group.id,
+        ),
+      ),
+    )
+    .join("");
+
+  const standaloneRoutes = routesWithDomain.filter(
+    (route) => !route.operationGroup,
+  );
+  const primaryRoutes = standaloneRoutes.filter(
+    (route) => route.exampleKind === "primary",
   );
 
   const primaryCards = primaryRoutes.map(renderCard).join("");
-  const variantCards = variantRoutes.map(renderCard).join("");
 
   return `
     <section class="category-section">
       <h2 class="category-title">${domain}</h2>
       <p class="category-desc">${DOMAIN_DESCRIPTIONS[domain]}</p>
-      <div class="examples-grid">
-        ${primaryCards}
-      </div>
+      ${operationGroupMarkup}
       ${
-        variantRoutes.length > 0
+        primaryRoutes.length > 0
           ? `
-        <div class="variant-block">
-          <div class="variant-title">Implemented variants</div>
-          <div class="examples-grid examples-grid--variants">
-            ${variantCards}
-          </div>
+        <div class="examples-grid">
+          ${primaryCards}
         </div>
       `
           : ""
@@ -185,7 +221,7 @@ export class HomePage {
       </nav>
       <div class="home-page">
         <h1>IFC Geometry Playground</h1>
-        <p class="home-desc">Explore implemented IFC geometry samples by shape-bearing domain, then use the implementation map to decide what to build next.</p>
+        <p class="home-desc">Explore implemented IFC geometry samples by operation, then use the implementation map to track entity-level coverage.</p>
         ${domainMarkup}
         ${renderImplementationMap()}
       </div>

--- a/src/pages/HomePage.ts
+++ b/src/pages/HomePage.ts
@@ -1,8 +1,13 @@
-import { routes, HOME_SECTIONS } from "../app/routes.ts";
+import {
+  routes,
+  GEOMETRY_DOMAINS,
+  implementationMap,
+} from "../app/routes.ts";
 import type {
   AvailableRoute,
   Difficulty,
-  HomeSection,
+  GeometryDomain,
+  ImplementationStatus,
   PlannedRoute,
   Route,
 } from "../app/routes.ts";
@@ -13,18 +18,27 @@ const DIFFICULTY_LABELS: Record<Difficulty, string> = {
   advanced: "Advanced",
 };
 
-const SECTION_DESCRIPTIONS: Record<HomeSection, string> = {
-  Foundations:
-    "Start with reusable inputs such as curves, profiles, and local placements before building geometry from them.",
-  "Build Solids":
-    "Turn profiles and paths into IFC solids, then compare representative implementations against profile-specific coverage.",
-  "Compose Solids":
-    "Combine and trim existing solids with boolean and CSG-style operations.",
+const STATUS_LABELS: Record<ImplementationStatus, string> = {
+  available: "Available",
+  partial: "Partial",
+  planned: "Planned",
 };
 
-function renderCard(route: Route): string {
+const DOMAIN_DESCRIPTIONS: Record<GeometryDomain, string> = {
+  Curves:
+    "Curve entities used as directrices, path segments, and profile boundaries.",
+  Profiles:
+    "Shape-bearing area profiles that can be extruded, revolved, or swept.",
+  "Swept Solids":
+    "Operations that turn profiles or curve paths into solids.",
+  "Boolean / CSG":
+    "Operations and primitive volumes for combining, trimming, and composing solids.",
+};
+
+function renderCard(route: AvailableRoute | PlannedRoute): string {
   const isPlanned = route.status === "planned";
   const description = route.description ?? "";
+  const entityBadge = `<span class="example-card-entity">${route.entity}</span>`;
 
   const difficultyBadge = route.difficulty
     ? `<span class="example-card-badge example-card-badge--${route.difficulty}">${DIFFICULTY_LABELS[route.difficulty]}</span>`
@@ -37,6 +51,7 @@ function renderCard(route: Route): string {
           <h3>${route.title}</h3>
           ${difficultyBadge}
         </div>
+        ${entityBadge}
         <p>${description}</p>
         <span class="example-card-status">Coming soon</span>
       </div>
@@ -50,39 +65,41 @@ function renderCard(route: Route): string {
           <h3>${route.title}</h3>
           ${difficultyBadge}
         </div>
+        ${entityBadge}
         <p>${description}</p>
       </div>
     </a>
   `;
 }
 
-function renderSection(section: HomeSection, sectionRoutes: Route[]): string {
-  if (sectionRoutes.length === 0) return "";
+function renderDomain(domain: GeometryDomain, domainRoutes: Route[]): string {
+  const routesWithDomain = domainRoutes.filter(hasHomeDomain);
+  if (routesWithDomain.length === 0) return "";
 
-  const featuredRoutes = sectionRoutes.filter(
-    (route) => route.homeKind === "featured",
+  const primaryRoutes = routesWithDomain.filter(
+    (route) => route.exampleKind === "primary",
   );
-  const coverageRoutes = sectionRoutes.filter(
-    (route) => route.homeKind === "coverage",
+  const variantRoutes = routesWithDomain.filter(
+    (route) => route.exampleKind === "variant",
   );
 
-  const featuredCards = featuredRoutes.map(renderCard).join("");
-  const coverageCards = coverageRoutes.map(renderCard).join("");
+  const primaryCards = primaryRoutes.map(renderCard).join("");
+  const variantCards = variantRoutes.map(renderCard).join("");
 
   return `
     <section class="category-section">
-      <h2 class="category-title">${section}</h2>
-      <p class="category-desc">${SECTION_DESCRIPTIONS[section]}</p>
+      <h2 class="category-title">${domain}</h2>
+      <p class="category-desc">${DOMAIN_DESCRIPTIONS[domain]}</p>
       <div class="examples-grid">
-        ${featuredCards}
+        ${primaryCards}
       </div>
       ${
-        coverageRoutes.length > 0
+        variantRoutes.length > 0
           ? `
-        <div class="coverage-block">
-          <div class="coverage-title">Coverage</div>
-          <div class="examples-grid examples-grid--coverage">
-            ${coverageCards}
+        <div class="variant-block">
+          <div class="variant-title">Implemented variants</div>
+          <div class="examples-grid examples-grid--variants">
+            ${variantCards}
           </div>
         </div>
       `
@@ -92,25 +109,74 @@ function renderSection(section: HomeSection, sectionRoutes: Route[]): string {
   `;
 }
 
-function hasHomeSection(route: Route): route is AvailableRoute | PlannedRoute {
-  return Boolean(route.homeSection);
+function renderDependencyList(dependsOn?: string[]): string {
+  if (!dependsOn || dependsOn.length === 0) return "";
+  return dependsOn
+    .map((dependency) => `<span class="map-dependency">${dependency}</span>`)
+    .join("");
+}
+
+function renderImplementationMap(): string {
+  const rows = implementationMap
+    .map((item) => {
+      const label = STATUS_LABELS[item.status];
+      const entity = item.routeHash
+        ? `<a href="${item.routeHash}" class="map-entity">${item.entity}</a>`
+        : `<span class="map-entity">${item.entity}</span>`;
+
+      return `
+        <tr>
+          <td>${entity}</td>
+          <td>${item.domain}</td>
+          <td><span class="status-pill status-pill--${item.status}">${label}</span></td>
+          <td>${item.description}</td>
+          <td class="map-dependencies">${renderDependencyList(item.dependsOn)}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  return `
+    <section class="category-section implementation-map-section">
+      <h2 class="category-title">Implementation Map</h2>
+      <p class="category-desc">Track implemented, partial, and planned IFC geometry entities without treating non-shape placement data as its own shape category.</p>
+      <div class="implementation-map">
+        <table>
+          <thead>
+            <tr>
+              <th>Entity</th>
+              <th>Domain</th>
+              <th>Status</th>
+              <th>Scope</th>
+              <th>Depends on</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    </section>
+  `;
+}
+
+function hasHomeDomain(route: Route): route is AvailableRoute | PlannedRoute {
+  return Boolean(route.domain);
 }
 
 export class HomePage {
   render(container: HTMLElement) {
-    const sampleRoutes = routes.filter(hasHomeSection);
+    const sampleRoutes = routes.filter(hasHomeDomain);
 
-    const bySection = new Map<HomeSection, Route[]>();
-    for (const section of HOME_SECTIONS) {
-      bySection.set(section, []);
+    const byDomain = new Map<GeometryDomain, Route[]>();
+    for (const domain of GEOMETRY_DOMAINS) {
+      byDomain.set(domain, []);
     }
 
     for (const route of sampleRoutes) {
-      bySection.get(route.homeSection)!.push(route);
+      byDomain.get(route.domain)!.push(route);
     }
 
-    const sectionMarkup = HOME_SECTIONS.map((section) =>
-      renderSection(section, bySection.get(section) ?? []),
+    const domainMarkup = GEOMETRY_DOMAINS.map((domain) =>
+      renderDomain(domain, byDomain.get(domain) ?? []),
     ).join("");
 
     container.innerHTML = `
@@ -119,8 +185,9 @@ export class HomePage {
       </nav>
       <div class="home-page">
         <h1>IFC Geometry Playground</h1>
-        <p class="home-desc">Learn IFC geometry from reusable inputs through solid generation and solid composition. Start with the featured concepts in each section, then use the coverage cards to inspect additional implemented variants.</p>
-        ${sectionMarkup}
+        <p class="home-desc">Explore implemented IFC geometry samples by shape-bearing domain, then use the implementation map to decide what to build next.</p>
+        ${domainMarkup}
+        ${renderImplementationMap()}
       </div>
     `;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -99,21 +99,49 @@ body {
   gap: 20px;
 }
 
-.variant-block {
-  margin-top: 18px;
+.examples-grid--variants {
+  gap: 16px;
 }
 
-.variant-title {
-  color: #6f8fb2;
-  font-size: 0.8em;
-  font-weight: bold;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.operation-group {
+  margin-bottom: 24px;
+}
+
+.operation-group:last-child {
+  margin-bottom: 18px;
+}
+
+.operation-header {
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) 1fr;
+  gap: 16px;
+  align-items: start;
   margin-bottom: 12px;
 }
 
-.examples-grid--variants {
-  gap: 16px;
+.operation-header h3 {
+  color: #4fc3f7;
+  font-size: 1em;
+  margin-bottom: 4px;
+}
+
+.operation-header p {
+  color: #7fa6c9;
+  font-size: 0.86em;
+  line-height: 1.5;
+}
+
+.operation-entity {
+  color: #b7d6e8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.74em;
+}
+
+@media (max-width: 640px) {
+  .operation-header {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
 }
 
 .example-card-link {

--- a/src/style.css
+++ b/src/style.css
@@ -52,7 +52,7 @@ body {
 /* Home Page */
 .home-page {
   padding: 40px;
-  max-width: 960px;
+  max-width: 1120px;
   margin: 0 auto;
   overflow-y: auto;
   height: 100%;
@@ -99,11 +99,11 @@ body {
   gap: 20px;
 }
 
-.coverage-block {
+.variant-block {
   margin-top: 18px;
 }
 
-.coverage-title {
+.variant-title {
   color: #6f8fb2;
   font-size: 0.8em;
   font-weight: bold;
@@ -112,7 +112,7 @@ body {
   margin-bottom: 12px;
 }
 
-.examples-grid--coverage {
+.examples-grid--variants {
   gap: 16px;
 }
 
@@ -167,6 +167,14 @@ body {
   line-height: 1.5;
 }
 
+.example-card-entity {
+  display: inline-block;
+  color: #b7d6e8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.76em;
+  margin-bottom: 10px;
+}
+
 .example-card-badge {
   font-size: 0.68em;
   font-weight: bold;
@@ -202,6 +210,105 @@ body {
   font-size: 0.75em;
   color: #4a6080;
   font-style: italic;
+}
+
+.implementation-map-section {
+  padding-bottom: 24px;
+}
+
+.implementation-map {
+  overflow-x: auto;
+  border: 1px solid #0f3460;
+  border-radius: 8px;
+  background: #121b34;
+}
+
+.implementation-map table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+.implementation-map th,
+.implementation-map td {
+  padding: 12px 14px;
+  border-bottom: 1px solid #0f3460;
+  text-align: left;
+  vertical-align: top;
+}
+
+.implementation-map th {
+  color: #81d4fa;
+  font-size: 0.76em;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  background: #16213e;
+}
+
+.implementation-map td {
+  color: #9fc4dd;
+  font-size: 0.86em;
+  line-height: 1.45;
+}
+
+.implementation-map tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.map-entity {
+  color: #4fc3f7;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+a.map-entity:hover {
+  color: #81d4fa;
+}
+
+.status-pill,
+.map-dependency {
+  display: inline-block;
+  border-radius: 999px;
+  font-size: 0.72em;
+  font-weight: bold;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.status-pill {
+  padding: 5px 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-pill--available {
+  background: #0d3b24;
+  color: #66bb6a;
+  border: 1px solid #2e7d32;
+}
+
+.status-pill--partial {
+  background: #26324d;
+  color: #9bbcff;
+  border: 1px solid #4b6599;
+}
+
+.status-pill--planned {
+  background: #2a2f3d;
+  color: #aab4c6;
+  border: 1px solid #485166;
+}
+
+.map-dependencies {
+  min-width: 150px;
+}
+
+.map-dependency {
+  color: #b7d6e8;
+  border: 1px solid #28466b;
+  padding: 4px 7px;
+  margin: 0 5px 5px 0;
 }
 
 /* Example Page Layout */


### PR DESCRIPTION
## Summary

- Replaces the home page's learning-section layout with shape-oriented domains and an entity-level implementation map.
- Removes placement from the home shape categories because it does not represent geometry by itself.
- Groups home examples by operation so extrusion, revolution, and swept disk each own their variants. Rectangle extrusion is now shown as an `IfcRectangleProfileDef` variant under `IfcExtrudedAreaSolid` instead of being the lone representative extrusion card.

## Impact

The home page now separates two concerns:

- Examples are organized by user-facing operation workflows.
- The implementation map tracks IFC entity-level coverage and dependencies.

This should make the upcoming `IfcCurve` work easier to place while keeping profile-specific samples discoverable under the operations that use them.

## Validation

- `bun run build`