### PR TITLE
Add IFC curve schema types and polyline sample

### DIFF
--- a/scripts/generate_ifc_schema.py
+++ b/scripts/generate_ifc_schema.py
@@ -2,9 +2,9 @@
 """Generate IFC schema JSON and TypeScript type definitions from IfcOpenShell.
 
 Extracts attribute metadata for IfcExtrudedAreaSolid, IfcRevolvedAreaSolid,
-and all supported subclasses of IfcParameterizedProfileDef (excluding
-explicitly unsupported entities such as IfcTrapeziumProfileDef), plus the
-supporting geometry entities.
+all supported subclasses of IfcParameterizedProfileDef (excluding explicitly
+unsupported entities such as IfcTrapeziumProfileDef), schema-complete IfcCurve
+interfaces, and the supporting geometry entities.
 
 Outputs:
   src/ifc/generated/schema.json  — raw IFC4 attribute schema (PascalCase)
@@ -35,14 +35,40 @@ OUTPUT_DIR = REPO_ROOT / "src" / "ifc" / "generated"
 GEOMETRY_ENTITIES = [
     "IfcCartesianPoint",
     "IfcDirection",
+    "IfcVector",
     "IfcAxis1Placement",
     "IfcAxis2Placement2D",
     "IfcAxis2Placement3D",
+    "IfcAxis2PlacementLinear",
+    "IfcCartesianPointList2D",
+    "IfcCartesianPointList3D",
+    "IfcPointByDistanceExpression",
+    "IfcPointOnCurve",
+    "IfcPointOnSurface",
+]
+
+CURVE_SEGMENT_ENTITIES = [
+    "IfcCompositeCurveSegment",
+    "IfcReparametrisedCompositeCurveSegment",
+    "IfcCurveSegment",
 ]
 
 # Parameterized profile entities that exist in IFC4 but are not yet implemented
 # in the playground runtime, so they remain excluded from generated TS unions.
 UNSUPPORTED_PROFILE_ENTITIES = frozenset({"IfcTrapeziumProfileDef"})
+
+# Curve entities that the generated runtime-facing union may accept. The schema
+# interfaces below are broader than this list, but unsupported curve families
+# stay out of IfcSupportedCurve until operations can interpret them.
+SUPPORTED_CURVE_ENTITIES = [
+    "IfcPolyline",
+    "IfcIndexedPolyCurve",
+    "IfcLine",
+    "IfcCircle",
+    "IfcEllipse",
+    "IfcTrimmedCurve",
+    "IfcCompositeCurve",
+]
 
 SOLID_ENTITIES = [
     "IfcExtrudedAreaSolid",
@@ -58,10 +84,17 @@ AREA_PROFILE_SOLID_ENTITIES = frozenset({"IfcExtrudedAreaSolid", "IfcRevolvedAre
 # the generated TypeScript (e.g. human-readable labels).
 ATTRS_TO_SKIP = frozenset({"ProfileName"})
 
-# TS-side narrowing for abstract IFC geometry base types that this playground
-# always materializes as concrete Cartesian points.
+# TS-side aliases for schema entities that are intentionally outside this
+# generator's current concrete entity set.
 TS_ENTITY_TYPE_OVERRIDES = {
-    "IfcPoint": "IfcCartesianPoint",
+    "IfcSurface": "IfcSurface",
+}
+
+# Abstract schema entities and selects that need named TS aliases because
+# concrete curve definitions refer to them. Opaque aliases intentionally mark
+# dependencies outside the curve/profile scope of this generator.
+OPAQUE_TS_ALIASES = {
+    "IfcSurface": "unknown",
 }
 
 # ---------------------------------------------------------------------------
@@ -121,7 +154,8 @@ def resolve_attribute_type(t) -> dict:
         return {
             "kind": "select",
             "ifcType": t.name(),
-            "options": [s.name() for s in t.select_list()],
+            "options": [resolve_attribute_type(s) for s in t.select_list()],
+            "optionNames": [s.name() for s in t.select_list()],
         }
 
     if isinstance(t, w.enumeration_type):
@@ -177,18 +211,46 @@ def get_supported_profile_entities(schema) -> list[str]:
     return entities
 
 
+def get_concrete_subtypes(schema, name: str) -> list[str]:
+    """Return all non-abstract descendants of an entity in schema order."""
+    root = schema.declaration_by_name(name)
+    entities: list[str] = []
+
+    def visit(decl) -> None:
+        if not decl.is_abstract():
+            entities.append(decl.name())
+        for child in decl.subtypes():
+            visit(child)
+
+    for child in root.subtypes():
+        visit(child)
+
+    return entities
+
+
 # ---------------------------------------------------------------------------
 # JSON schema generation
 # ---------------------------------------------------------------------------
 
 
-def generate_schema_json(schema, profile_entities: list[str], errors: list[str]) -> dict:
+def generate_schema_json(
+    schema,
+    profile_entities: list[str],
+    curve_entities: list[str],
+    errors: list[str],
+) -> dict:
     """Build the full schema dict for all target entities.
 
     Any per-entity errors are appended to *errors* so the caller can decide
     whether to exit with a non-zero status.
     """
-    all_target_entities = GEOMETRY_ENTITIES + profile_entities + SOLID_ENTITIES
+    all_target_entities = (
+        GEOMETRY_ENTITIES
+        + CURVE_SEGMENT_ENTITIES
+        + curve_entities
+        + profile_entities
+        + SOLID_ENTITIES
+    )
     entities: dict[str, dict] = {}
     for name in all_target_entities:
         try:
@@ -217,6 +279,22 @@ def pascal_to_camel(name: str) -> str:
     return name[0].lower() + name[1:]
 
 
+def unique_preserve_order(values: list[str]) -> list[str]:
+    """Return values with duplicates removed while preserving first occurrence."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def parenthesize_union(ts_type: str) -> str:
+    """Wrap a TS union before composing it into array syntax."""
+    return f"({ts_type})" if " | " in ts_type else ts_type
+
+
 def type_info_to_ts(type_info: dict) -> str:
     """Convert a resolved type_info dict to a TypeScript type expression."""
     kind = type_info.get("kind")
@@ -235,10 +313,15 @@ def type_info_to_ts(type_info: dict) -> str:
         return TS_ENTITY_TYPE_OVERRIDES.get(entity_name, entity_name)
     if kind == "array":
         element_ts = type_info_to_ts(type_info.get("element", {"kind": "unknown"}))
-        return f"{element_ts}[]"
+        return f"{parenthesize_union(element_ts)}[]"
     if kind == "select":
-        options = type_info.get("options", [])
-        return " | ".join(options)
+        option_types: list[str] = []
+        for option in type_info.get("options", []):
+            if isinstance(option, dict):
+                option_types.append(type_info_to_ts(option))
+            else:
+                option_types.append(str(option))
+        return " | ".join(unique_preserve_order(option_types)) or "unknown"
     return "unknown"
 
 
@@ -262,7 +345,17 @@ def generate_ts_interface(entity_info: dict) -> str:
     return "\n".join(lines)
 
 
-def generate_ts_file(schema, profile_entities: list[str]) -> str:
+def generate_ts_union(name: str, members: list[str]) -> str:
+    """Render an exported TypeScript union alias."""
+    union_lines = [f"export type {name} ="]
+    for i, member in enumerate(members):
+        sep = "  | " if i > 0 else "    "
+        union_lines.append(f"{sep}{member}")
+    union_lines[-1] += ";"
+    return "\n".join(union_lines)
+
+
+def generate_ts_file(schema, profile_entities: list[str], curve_entities: list[str]) -> str:
     """Generate the full TypeScript source file content."""
     blocks: list[str] = []
 
@@ -284,6 +377,48 @@ def generate_ts_file(schema, profile_entities: list[str]) -> str:
     for name in GEOMETRY_ENTITIES:
         entity_info = get_entity_info(schema, name)
         blocks.append(generate_ts_interface(entity_info))
+
+    blocks.append(
+        generate_ts_union(
+            "IfcCartesianPointList",
+            ["IfcCartesianPointList2D", "IfcCartesianPointList3D"],
+        )
+    )
+    blocks.append(
+        generate_ts_union(
+            "IfcPoint",
+            ["IfcCartesianPoint", "IfcPointByDistanceExpression", "IfcPointOnCurve", "IfcPointOnSurface"],
+        )
+    )
+    blocks.append(
+        generate_ts_union(
+            "IfcPlacement",
+            ["IfcAxis1Placement", "IfcAxis2Placement2D", "IfcAxis2Placement3D", "IfcAxis2PlacementLinear"],
+        )
+    )
+    for name, ts_type in OPAQUE_TS_ALIASES.items():
+        blocks.append(f"export type {name} = {ts_type};")
+
+    # --- Curve entities --------------------------------------------------
+    blocks.append("// ── Curve segment entities ────────────────────────────────────────")
+    for name in CURVE_SEGMENT_ENTITIES:
+        entity_info = get_entity_info(schema, name)
+        blocks.append(generate_ts_interface(entity_info))
+
+    blocks.append(generate_ts_union("IfcSegment", CURVE_SEGMENT_ENTITIES))
+
+    blocks.append("// ── Curve entities ────────────────────────────────────────────────")
+    for name in curve_entities:
+        entity_info = get_entity_info(schema, name)
+        blocks.append(generate_ts_interface(entity_info))
+
+    blocks.append(generate_ts_union("IfcBoundedCurve", get_concrete_subtypes(schema, "IfcBoundedCurve")))
+    blocks.append(generate_ts_union("IfcCurve", curve_entities))
+    blocks.append(
+        "/** Runtime-facing curve subset. This is intentionally narrower than\n"
+        " *  schema-complete IfcCurve until operations support every family. */"
+    )
+    blocks.append(generate_ts_union("IfcSupportedCurve", SUPPORTED_CURVE_ENTITIES))
 
     # --- Profile entities -----------------------------------------------
     blocks.append("// ── Parameterized profile definitions ────────────────────────────")
@@ -379,18 +514,19 @@ def main() -> None:
     print(f"Loading {SCHEMA_NAME} schema …")
     schema = ifcopenshell.schema_by_name(SCHEMA_NAME)
     profile_entities = get_supported_profile_entities(schema)
+    curve_entities = get_concrete_subtypes(schema, "IfcCurve")
 
     errors: list[str] = []
 
     # -- JSON output -------------------------------------------------------
     json_path = OUTPUT_DIR / "schema.json"
-    schema_data = generate_schema_json(schema, profile_entities, errors)
+    schema_data = generate_schema_json(schema, profile_entities, curve_entities, errors)
     json_path.write_text(json.dumps(schema_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(f"Wrote {json_path.relative_to(REPO_ROOT)}")
 
     # -- TypeScript output -------------------------------------------------
     ts_path = OUTPUT_DIR / "schema.ts"
-    ts_content = generate_ts_file(schema, profile_entities)
+    ts_content = generate_ts_file(schema, profile_entities, curve_entities)
     ts_path.write_text(ts_content, encoding="utf-8")
     print(f"Wrote {ts_path.relative_to(REPO_ROOT)}")
 

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -17,9 +17,11 @@ import { extrusionUShapeSample } from "../ifc/samples/extrusion.u-shape.ts";
 import { extrusionZShapeSample } from "../ifc/samples/extrusion.z-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
+import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
+  "curve-polyline": curvePolylineSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -14,7 +14,11 @@ export const GEOMETRY_DOMAINS: GeometryDomain[] = [
 export type Difficulty = "beginner" | "intermediate" | "advanced";
 export type ExampleKind = "primary" | "variant";
 export type ImplementationStatus = "available" | "partial" | "planned";
-export type OperationGroupId = "extrusion" | "revolution" | "swept-disk";
+export type OperationGroupId =
+  | "curve-primitives"
+  | "extrusion"
+  | "revolution"
+  | "swept-disk";
 
 interface BaseRoute {
   hash: string;
@@ -78,6 +82,14 @@ export interface OperationGroup {
 
 export const OPERATION_GROUPS: OperationGroup[] = [
   {
+    id: "curve-primitives",
+    domain: "Curves",
+    title: "Curve Primitives",
+    entity: "IfcCurve",
+    description:
+      "Inspect curve entities before they are reused as directrices and profile boundaries.",
+  },
+  {
     id: "extrusion",
     domain: "Swept Solids",
     title: "Extrusion",
@@ -106,15 +118,54 @@ export const OPERATION_GROUPS: OperationGroup[] = [
 export const routes: Route[] = [
   { hash: "#/", title: "Home" },
   {
-    hash: "#/examples/curves",
-    title: "Curves",
+    hash: "#/examples/curve-polyline",
+    title: "Polyline",
     description:
-      "Explore curve primitives before using them as directrices for sweep-based geometry.",
+      "Inspect an IfcPolyline as ordered cartesian points joined by straight segments.",
+    sampleId: "curve-polyline",
+    domain: "Curves",
+    difficulty: "beginner",
+    exampleKind: "variant",
+    status: "available",
+    entity: "IfcPolyline",
+    dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
+  },
+  {
+    hash: "#/examples/curve-indexed-polycurve",
+    title: "Indexed PolyCurve",
+    description:
+      "Represent compact line and arc segments through indexed point lists.",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "primary",
+    status: "planned",
+    entity: "IfcIndexedPolyCurve",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    hash: "#/examples/curve-circle",
+    title: "Circle",
+    description:
+      "Define a circular curve from an axis placement and radius.",
     domain: "Curves",
     difficulty: "beginner",
     exampleKind: "primary",
     status: "planned",
-    entity: "IfcCurve",
+    entity: "IfcCircle",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    hash: "#/examples/curve-ellipse",
+    title: "Ellipse",
+    description:
+      "Define an elliptical curve from an axis placement and two semi-axis lengths.",
+    domain: "Curves",
+    difficulty: "beginner",
+    exampleKind: "primary",
+    status: "planned",
+    entity: "IfcEllipse",
+    dependsOn: ["IfcCurve"],
   },
   {
     hash: "#/examples/profiles",
@@ -401,15 +452,15 @@ export const implementationMap: ImplementationMapItem[] = [
   {
     entity: "IfcCurve",
     domain: "Curves",
-    status: "planned",
+    status: "partial",
     description: "Abstract curve base for directrices and profile boundaries.",
   },
   {
     entity: "IfcPolyline",
     domain: "Curves",
     status: "available",
-    description: "Polyline directrix used by the swept disk sample.",
-    routeHash: "#/examples/swept-disk",
+    description: "Ordered cartesian points joined by straight segments.",
+    routeHash: "#/examples/curve-polyline",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/engine/materials.ts
+++ b/src/engine/materials.ts
@@ -11,6 +11,14 @@ export function createSolidMaterial(scene: Scene, color: Color3, alpha = 1): Sta
   return mat
 }
 
+export function getOrCreateSolidMaterial(scene: Scene, name: string, color: Color3, alpha = 1): StandardMaterial {
+  const existing = scene.getMaterialByName(name)
+  const mat = existing instanceof StandardMaterial ? existing : new StandardMaterial(name, scene)
+  mat.diffuseColor = color
+  mat.alpha = alpha
+  return mat
+}
+
 export function createWireframeMaterial(scene: Scene, color: Color3): StandardMaterial {
   const mat = new StandardMaterial(`wire_${nextId()}`, scene)
   mat.diffuseColor = color

--- a/src/ifc/generated/schema.json
+++ b/src/ifc/generated/schema.json
@@ -37,6 +37,28 @@
         }
       ]
     },
+    "IfcVector": {
+      "name": "IfcVector",
+      "supertype": "IfcGeometricRepresentationItem",
+      "attributes": [
+        {
+          "name": "Orientation",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcDirection"
+          }
+        },
+        {
+          "name": "Magnitude",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
     "IfcAxis1Placement": {
       "name": "IfcAxis1Placement",
       "supertype": "IfcPlacement",
@@ -107,6 +129,1660 @@
           "type": {
             "kind": "entity",
             "name": "IfcDirection"
+          }
+        }
+      ]
+    },
+    "IfcAxis2PlacementLinear": {
+      "name": "IfcAxis2PlacementLinear",
+      "supertype": "IfcPlacement",
+      "attributes": [
+        {
+          "name": "Location",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPoint"
+          }
+        },
+        {
+          "name": "Axis",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcDirection"
+          }
+        },
+        {
+          "name": "RefDirection",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcDirection"
+          }
+        }
+      ]
+    },
+    "IfcCartesianPointList2D": {
+      "name": "IfcCartesianPointList2D",
+      "supertype": "IfcCartesianPointList",
+      "attributes": [
+        {
+          "name": "CoordList",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "array",
+              "aggregation": "list",
+              "element": {
+                "kind": "number",
+                "ifcType": "IfcLengthMeasure"
+              }
+            }
+          }
+        },
+        {
+          "name": "TagList",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "string",
+              "ifcType": "IfcLabel"
+            }
+          }
+        }
+      ]
+    },
+    "IfcCartesianPointList3D": {
+      "name": "IfcCartesianPointList3D",
+      "supertype": "IfcCartesianPointList",
+      "attributes": [
+        {
+          "name": "CoordList",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "array",
+              "aggregation": "list",
+              "element": {
+                "kind": "number",
+                "ifcType": "IfcLengthMeasure"
+              }
+            }
+          }
+        },
+        {
+          "name": "TagList",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "string",
+              "ifcType": "IfcLabel"
+            }
+          }
+        }
+      ]
+    },
+    "IfcPointByDistanceExpression": {
+      "name": "IfcPointByDistanceExpression",
+      "supertype": "IfcPoint",
+      "attributes": [
+        {
+          "name": "DistanceAlong",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcCurveMeasureSelect",
+            "options": [
+              {
+                "kind": "number",
+                "ifcType": "IfcLengthMeasure"
+              },
+              {
+                "kind": "number",
+                "ifcType": "IfcParameterValue"
+              }
+            ],
+            "optionNames": [
+              "IfcLengthMeasure",
+              "IfcParameterValue"
+            ]
+          }
+        },
+        {
+          "name": "OffsetLateral",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "OffsetVertical",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "OffsetLongitudinal",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        }
+      ]
+    },
+    "IfcPointOnCurve": {
+      "name": "IfcPointOnCurve",
+      "supertype": "IfcPoint",
+      "attributes": [
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "PointParameter",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcParameterValue"
+          }
+        }
+      ]
+    },
+    "IfcPointOnSurface": {
+      "name": "IfcPointOnSurface",
+      "supertype": "IfcPoint",
+      "attributes": [
+        {
+          "name": "BasisSurface",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcSurface"
+          }
+        },
+        {
+          "name": "PointParameterU",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcParameterValue"
+          }
+        },
+        {
+          "name": "PointParameterV",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcParameterValue"
+          }
+        }
+      ]
+    },
+    "IfcCompositeCurveSegment": {
+      "name": "IfcCompositeCurveSegment",
+      "supertype": "IfcSegment",
+      "attributes": [
+        {
+          "name": "Transition",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcTransitionCode",
+            "values": [
+              "CONTINUOUS",
+              "CONTSAMEGRADIENT",
+              "CONTSAMEGRADIENTSAMECURVATURE",
+              "DISCONTINUOUS"
+            ]
+          }
+        },
+        {
+          "name": "SameSense",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcBoolean"
+          }
+        },
+        {
+          "name": "ParentCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        }
+      ]
+    },
+    "IfcReparametrisedCompositeCurveSegment": {
+      "name": "IfcReparametrisedCompositeCurveSegment",
+      "supertype": "IfcCompositeCurveSegment",
+      "attributes": [
+        {
+          "name": "Transition",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcTransitionCode",
+            "values": [
+              "CONTINUOUS",
+              "CONTSAMEGRADIENT",
+              "CONTSAMEGRADIENTSAMECURVATURE",
+              "DISCONTINUOUS"
+            ]
+          }
+        },
+        {
+          "name": "SameSense",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcBoolean"
+          }
+        },
+        {
+          "name": "ParentCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "ParamLength",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcParameterValue"
+          }
+        }
+      ]
+    },
+    "IfcCurveSegment": {
+      "name": "IfcCurveSegment",
+      "supertype": "IfcSegment",
+      "attributes": [
+        {
+          "name": "Transition",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcTransitionCode",
+            "values": [
+              "CONTINUOUS",
+              "CONTSAMEGRADIENT",
+              "CONTSAMEGRADIENTSAMECURVATURE",
+              "DISCONTINUOUS"
+            ]
+          }
+        },
+        {
+          "name": "Placement",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPlacement"
+          }
+        },
+        {
+          "name": "SegmentStart",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcCurveMeasureSelect",
+            "options": [
+              {
+                "kind": "number",
+                "ifcType": "IfcLengthMeasure"
+              },
+              {
+                "kind": "number",
+                "ifcType": "IfcParameterValue"
+              }
+            ],
+            "optionNames": [
+              "IfcLengthMeasure",
+              "IfcParameterValue"
+            ]
+          }
+        },
+        {
+          "name": "SegmentLength",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcCurveMeasureSelect",
+            "options": [
+              {
+                "kind": "number",
+                "ifcType": "IfcLengthMeasure"
+              },
+              {
+                "kind": "number",
+                "ifcType": "IfcParameterValue"
+              }
+            ],
+            "optionNames": [
+              "IfcLengthMeasure",
+              "IfcParameterValue"
+            ]
+          }
+        },
+        {
+          "name": "ParentCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        }
+      ]
+    },
+    "IfcBSplineCurveWithKnots": {
+      "name": "IfcBSplineCurveWithKnots",
+      "supertype": "IfcBSplineCurve",
+      "attributes": [
+        {
+          "name": "Degree",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcInteger"
+          }
+        },
+        {
+          "name": "ControlPointsList",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcCartesianPoint"
+            }
+          }
+        },
+        {
+          "name": "CurveForm",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcBSplineCurveForm",
+            "values": [
+              "CIRCULAR_ARC",
+              "ELLIPTIC_ARC",
+              "HYPERBOLIC_ARC",
+              "PARABOLIC_ARC",
+              "POLYLINE_FORM",
+              "UNSPECIFIED"
+            ]
+          }
+        },
+        {
+          "name": "ClosedCurve",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "KnotMultiplicities",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcInteger"
+            }
+          }
+        },
+        {
+          "name": "Knots",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcParameterValue"
+            }
+          }
+        },
+        {
+          "name": "KnotSpec",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcKnotType",
+            "values": [
+              "PIECEWISE_BEZIER_KNOTS",
+              "QUASI_UNIFORM_KNOTS",
+              "UNIFORM_KNOTS",
+              "UNSPECIFIED"
+            ]
+          }
+        }
+      ]
+    },
+    "IfcRationalBSplineCurveWithKnots": {
+      "name": "IfcRationalBSplineCurveWithKnots",
+      "supertype": "IfcBSplineCurveWithKnots",
+      "attributes": [
+        {
+          "name": "Degree",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcInteger"
+          }
+        },
+        {
+          "name": "ControlPointsList",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcCartesianPoint"
+            }
+          }
+        },
+        {
+          "name": "CurveForm",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcBSplineCurveForm",
+            "values": [
+              "CIRCULAR_ARC",
+              "ELLIPTIC_ARC",
+              "HYPERBOLIC_ARC",
+              "PARABOLIC_ARC",
+              "POLYLINE_FORM",
+              "UNSPECIFIED"
+            ]
+          }
+        },
+        {
+          "name": "ClosedCurve",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "KnotMultiplicities",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcInteger"
+            }
+          }
+        },
+        {
+          "name": "Knots",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcParameterValue"
+            }
+          }
+        },
+        {
+          "name": "KnotSpec",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcKnotType",
+            "values": [
+              "PIECEWISE_BEZIER_KNOTS",
+              "QUASI_UNIFORM_KNOTS",
+              "UNIFORM_KNOTS",
+              "UNSPECIFIED"
+            ]
+          }
+        },
+        {
+          "name": "WeightsData",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcReal"
+            }
+          }
+        }
+      ]
+    },
+    "IfcCompositeCurve": {
+      "name": "IfcCompositeCurve",
+      "supertype": "IfcBoundedCurve",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        }
+      ]
+    },
+    "IfcCompositeCurveOnSurface": {
+      "name": "IfcCompositeCurveOnSurface",
+      "supertype": "IfcCompositeCurve",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        }
+      ]
+    },
+    "IfcBoundaryCurve": {
+      "name": "IfcBoundaryCurve",
+      "supertype": "IfcCompositeCurveOnSurface",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        }
+      ]
+    },
+    "IfcOuterBoundaryCurve": {
+      "name": "IfcOuterBoundaryCurve",
+      "supertype": "IfcBoundaryCurve",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        }
+      ]
+    },
+    "IfcGradientCurve": {
+      "name": "IfcGradientCurve",
+      "supertype": "IfcCompositeCurve",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "BaseCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcBoundedCurve"
+          }
+        },
+        {
+          "name": "EndPoint",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPlacement"
+          }
+        }
+      ]
+    },
+    "IfcSegmentedReferenceCurve": {
+      "name": "IfcSegmentedReferenceCurve",
+      "supertype": "IfcCompositeCurve",
+      "attributes": [
+        {
+          "name": "Segments",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcSegment"
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "BaseCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcBoundedCurve"
+          }
+        },
+        {
+          "name": "EndPoint",
+          "optional": true,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPlacement"
+          }
+        }
+      ]
+    },
+    "IfcIndexedPolyCurve": {
+      "name": "IfcIndexedPolyCurve",
+      "supertype": "IfcBoundedCurve",
+      "attributes": [
+        {
+          "name": "Points",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCartesianPointList"
+          }
+        },
+        {
+          "name": "Segments",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "select",
+              "ifcType": "IfcSegmentIndexSelect",
+              "options": [
+                {
+                  "kind": "array",
+                  "aggregation": "list",
+                  "element": {
+                    "kind": "number",
+                    "ifcType": "IfcPositiveInteger"
+                  },
+                  "ifcType": "IfcArcIndex"
+                },
+                {
+                  "kind": "array",
+                  "aggregation": "list",
+                  "element": {
+                    "kind": "number",
+                    "ifcType": "IfcPositiveInteger"
+                  },
+                  "ifcType": "IfcLineIndex"
+                }
+              ],
+              "optionNames": [
+                "IfcArcIndex",
+                "IfcLineIndex"
+              ]
+            }
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": true,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcBoolean"
+          }
+        }
+      ]
+    },
+    "IfcPolyline": {
+      "name": "IfcPolyline",
+      "supertype": "IfcBoundedCurve",
+      "attributes": [
+        {
+          "name": "Points",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcCartesianPoint"
+            }
+          }
+        }
+      ]
+    },
+    "IfcTrimmedCurve": {
+      "name": "IfcTrimmedCurve",
+      "supertype": "IfcBoundedCurve",
+      "attributes": [
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "Trim1",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "set",
+            "element": {
+              "kind": "select",
+              "ifcType": "IfcTrimmingSelect",
+              "options": [
+                {
+                  "kind": "entity",
+                  "name": "IfcCartesianPoint"
+                },
+                {
+                  "kind": "number",
+                  "ifcType": "IfcParameterValue"
+                }
+              ],
+              "optionNames": [
+                "IfcCartesianPoint",
+                "IfcParameterValue"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Trim2",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "set",
+            "element": {
+              "kind": "select",
+              "ifcType": "IfcTrimmingSelect",
+              "options": [
+                {
+                  "kind": "entity",
+                  "name": "IfcCartesianPoint"
+                },
+                {
+                  "kind": "number",
+                  "ifcType": "IfcParameterValue"
+                }
+              ],
+              "optionNames": [
+                "IfcCartesianPoint",
+                "IfcParameterValue"
+              ]
+            }
+          }
+        },
+        {
+          "name": "SenseAgreement",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcBoolean"
+          }
+        },
+        {
+          "name": "MasterRepresentation",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcTrimmingPreference",
+            "values": [
+              "CARTESIAN",
+              "PARAMETER",
+              "UNSPECIFIED"
+            ]
+          }
+        }
+      ]
+    },
+    "IfcCircle": {
+      "name": "IfcCircle",
+      "supertype": "IfcConic",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "Radius",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcPositiveLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcEllipse": {
+      "name": "IfcEllipse",
+      "supertype": "IfcConic",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "SemiAxis1",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcPositiveLengthMeasure"
+          }
+        },
+        {
+          "name": "SemiAxis2",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcPositiveLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcLine": {
+      "name": "IfcLine",
+      "supertype": "IfcCurve",
+      "attributes": [
+        {
+          "name": "Pnt",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCartesianPoint"
+          }
+        },
+        {
+          "name": "Dir",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcVector"
+          }
+        }
+      ]
+    },
+    "IfcOffsetCurve2D": {
+      "name": "IfcOffsetCurve2D",
+      "supertype": "IfcOffsetCurve",
+      "attributes": [
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "Distance",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        }
+      ]
+    },
+    "IfcOffsetCurve3D": {
+      "name": "IfcOffsetCurve3D",
+      "supertype": "IfcOffsetCurve",
+      "attributes": [
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "Distance",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "SelfIntersect",
+          "optional": false,
+          "type": {
+            "kind": "boolean",
+            "ifcType": "IfcLogical"
+          }
+        },
+        {
+          "name": "RefDirection",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcDirection"
+          }
+        }
+      ]
+    },
+    "IfcOffsetCurveByDistances": {
+      "name": "IfcOffsetCurveByDistances",
+      "supertype": "IfcOffsetCurve",
+      "attributes": [
+        {
+          "name": "BasisCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "OffsetValues",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcPointByDistanceExpression"
+            }
+          }
+        },
+        {
+          "name": "Tag",
+          "optional": true,
+          "type": {
+            "kind": "string",
+            "ifcType": "IfcLabel"
+          }
+        }
+      ]
+    },
+    "IfcPcurve": {
+      "name": "IfcPcurve",
+      "supertype": "IfcCurve",
+      "attributes": [
+        {
+          "name": "BasisSurface",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcSurface"
+          }
+        },
+        {
+          "name": "ReferenceCurve",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        }
+      ]
+    },
+    "IfcPolynomialCurve": {
+      "name": "IfcPolynomialCurve",
+      "supertype": "IfcCurve",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcPlacement"
+          }
+        },
+        {
+          "name": "CoefficientsX",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcReal"
+            }
+          }
+        },
+        {
+          "name": "CoefficientsY",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcReal"
+            }
+          }
+        },
+        {
+          "name": "CoefficientsZ",
+          "optional": true,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "number",
+              "ifcType": "IfcReal"
+            }
+          }
+        }
+      ]
+    },
+    "IfcClothoid": {
+      "name": "IfcClothoid",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "ClothoidConstant",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcCosineSpiral": {
+      "name": "IfcCosineSpiral",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "CosineTerm",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "ConstantTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcSecondOrderPolynomialSpiral": {
+      "name": "IfcSecondOrderPolynomialSpiral",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "QuadraticTerm",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "LinearTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "ConstantTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcSeventhOrderPolynomialSpiral": {
+      "name": "IfcSeventhOrderPolynomialSpiral",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "SepticTerm",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "SexticTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "QuinticTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "QuarticTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "CubicTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "QuadraticTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "LinearTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "ConstantTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcSineSpiral": {
+      "name": "IfcSineSpiral",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "SineTerm",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "LinearTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "ConstantTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcThirdOrderPolynomialSpiral": {
+      "name": "IfcThirdOrderPolynomialSpiral",
+      "supertype": "IfcSpiral",
+      "attributes": [
+        {
+          "name": "Position",
+          "optional": false,
+          "type": {
+            "kind": "select",
+            "ifcType": "IfcAxis2Placement",
+            "options": [
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement2D"
+              },
+              {
+                "kind": "entity",
+                "name": "IfcAxis2Placement3D"
+              }
+            ],
+            "optionNames": [
+              "IfcAxis2Placement2D",
+              "IfcAxis2Placement3D"
+            ]
+          }
+        },
+        {
+          "name": "CubicTerm",
+          "optional": false,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "QuadraticTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "LinearTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        },
+        {
+          "name": "ConstantTerm",
+          "optional": true,
+          "type": {
+            "kind": "number",
+            "ifcType": "IfcLengthMeasure"
+          }
+        }
+      ]
+    },
+    "IfcSurfaceCurve": {
+      "name": "IfcSurfaceCurve",
+      "supertype": "IfcCurve",
+      "attributes": [
+        {
+          "name": "Curve3D",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "AssociatedGeometry",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcPcurve"
+            }
+          }
+        },
+        {
+          "name": "MasterRepresentation",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcPreferredSurfaceCurveRepresentation",
+            "values": [
+              "CURVE3D",
+              "PCURVE_S1",
+              "PCURVE_S2"
+            ]
+          }
+        }
+      ]
+    },
+    "IfcIntersectionCurve": {
+      "name": "IfcIntersectionCurve",
+      "supertype": "IfcSurfaceCurve",
+      "attributes": [
+        {
+          "name": "Curve3D",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "AssociatedGeometry",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcPcurve"
+            }
+          }
+        },
+        {
+          "name": "MasterRepresentation",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcPreferredSurfaceCurveRepresentation",
+            "values": [
+              "CURVE3D",
+              "PCURVE_S1",
+              "PCURVE_S2"
+            ]
+          }
+        }
+      ]
+    },
+    "IfcSeamCurve": {
+      "name": "IfcSeamCurve",
+      "supertype": "IfcSurfaceCurve",
+      "attributes": [
+        {
+          "name": "Curve3D",
+          "optional": false,
+          "type": {
+            "kind": "entity",
+            "name": "IfcCurve"
+          }
+        },
+        {
+          "name": "AssociatedGeometry",
+          "optional": false,
+          "type": {
+            "kind": "array",
+            "aggregation": "list",
+            "element": {
+              "kind": "entity",
+              "name": "IfcPcurve"
+            }
+          }
+        },
+        {
+          "name": "MasterRepresentation",
+          "optional": false,
+          "type": {
+            "kind": "enumeration",
+            "ifcType": "IfcPreferredSurfaceCurveRepresentation",
+            "values": [
+              "CURVE3D",
+              "PCURVE_S1",
+              "PCURVE_S2"
+            ]
           }
         }
       ]

--- a/src/ifc/generated/schema.ts
+++ b/src/ifc/generated/schema.ts
@@ -18,24 +18,390 @@ export interface IfcDirection {
   directionRatios: number[];
 }
 
+export interface IfcVector {
+  type: 'IfcVector';
+  orientation: IfcDirection;
+  magnitude: number;
+}
+
 export interface IfcAxis1Placement {
   type: 'IfcAxis1Placement';
-  location: IfcCartesianPoint;
+  location: IfcPoint;
   axis?: IfcDirection;
 }
 
 export interface IfcAxis2Placement2D {
   type: 'IfcAxis2Placement2D';
-  location: IfcCartesianPoint;
+  location: IfcPoint;
   refDirection?: IfcDirection;
 }
 
 export interface IfcAxis2Placement3D {
   type: 'IfcAxis2Placement3D';
-  location: IfcCartesianPoint;
+  location: IfcPoint;
   axis?: IfcDirection;
   refDirection?: IfcDirection;
 }
+
+export interface IfcAxis2PlacementLinear {
+  type: 'IfcAxis2PlacementLinear';
+  location: IfcPoint;
+  axis?: IfcDirection;
+  refDirection?: IfcDirection;
+}
+
+export interface IfcCartesianPointList2D {
+  type: 'IfcCartesianPointList2D';
+  coordList: number[][];
+  tagList?: string[];
+}
+
+export interface IfcCartesianPointList3D {
+  type: 'IfcCartesianPointList3D';
+  coordList: number[][];
+  tagList?: string[];
+}
+
+export interface IfcPointByDistanceExpression {
+  type: 'IfcPointByDistanceExpression';
+  distanceAlong: number;
+  offsetLateral?: number;
+  offsetVertical?: number;
+  offsetLongitudinal?: number;
+  basisCurve: IfcCurve;
+}
+
+export interface IfcPointOnCurve {
+  type: 'IfcPointOnCurve';
+  basisCurve: IfcCurve;
+  pointParameter: number;
+}
+
+export interface IfcPointOnSurface {
+  type: 'IfcPointOnSurface';
+  basisSurface: IfcSurface;
+  pointParameterU: number;
+  pointParameterV: number;
+}
+
+export type IfcCartesianPointList =
+    IfcCartesianPointList2D
+  | IfcCartesianPointList3D;
+
+export type IfcPoint =
+    IfcCartesianPoint
+  | IfcPointByDistanceExpression
+  | IfcPointOnCurve
+  | IfcPointOnSurface;
+
+export type IfcPlacement =
+    IfcAxis1Placement
+  | IfcAxis2Placement2D
+  | IfcAxis2Placement3D
+  | IfcAxis2PlacementLinear;
+
+export type IfcSurface = unknown;
+
+// ── Curve segment entities ────────────────────────────────────────
+
+export interface IfcCompositeCurveSegment {
+  type: 'IfcCompositeCurveSegment';
+  transition: 'CONTINUOUS' | 'CONTSAMEGRADIENT' | 'CONTSAMEGRADIENTSAMECURVATURE' | 'DISCONTINUOUS';
+  sameSense: boolean;
+  parentCurve: IfcCurve;
+}
+
+export interface IfcReparametrisedCompositeCurveSegment {
+  type: 'IfcReparametrisedCompositeCurveSegment';
+  transition: 'CONTINUOUS' | 'CONTSAMEGRADIENT' | 'CONTSAMEGRADIENTSAMECURVATURE' | 'DISCONTINUOUS';
+  sameSense: boolean;
+  parentCurve: IfcCurve;
+  paramLength: number;
+}
+
+export interface IfcCurveSegment {
+  type: 'IfcCurveSegment';
+  transition: 'CONTINUOUS' | 'CONTSAMEGRADIENT' | 'CONTSAMEGRADIENTSAMECURVATURE' | 'DISCONTINUOUS';
+  placement: IfcPlacement;
+  segmentStart: number;
+  segmentLength: number;
+  parentCurve: IfcCurve;
+}
+
+export type IfcSegment =
+    IfcCompositeCurveSegment
+  | IfcReparametrisedCompositeCurveSegment
+  | IfcCurveSegment;
+
+// ── Curve entities ────────────────────────────────────────────────
+
+export interface IfcBSplineCurveWithKnots {
+  type: 'IfcBSplineCurveWithKnots';
+  degree: number;
+  controlPointsList: IfcCartesianPoint[];
+  curveForm: 'CIRCULAR_ARC' | 'ELLIPTIC_ARC' | 'HYPERBOLIC_ARC' | 'PARABOLIC_ARC' | 'POLYLINE_FORM' | 'UNSPECIFIED';
+  closedCurve: boolean;
+  selfIntersect: boolean;
+  knotMultiplicities: number[];
+  knots: number[];
+  knotSpec: 'PIECEWISE_BEZIER_KNOTS' | 'QUASI_UNIFORM_KNOTS' | 'UNIFORM_KNOTS' | 'UNSPECIFIED';
+}
+
+export interface IfcRationalBSplineCurveWithKnots {
+  type: 'IfcRationalBSplineCurveWithKnots';
+  degree: number;
+  controlPointsList: IfcCartesianPoint[];
+  curveForm: 'CIRCULAR_ARC' | 'ELLIPTIC_ARC' | 'HYPERBOLIC_ARC' | 'PARABOLIC_ARC' | 'POLYLINE_FORM' | 'UNSPECIFIED';
+  closedCurve: boolean;
+  selfIntersect: boolean;
+  knotMultiplicities: number[];
+  knots: number[];
+  knotSpec: 'PIECEWISE_BEZIER_KNOTS' | 'QUASI_UNIFORM_KNOTS' | 'UNIFORM_KNOTS' | 'UNSPECIFIED';
+  weightsData: number[];
+}
+
+export interface IfcCompositeCurve {
+  type: 'IfcCompositeCurve';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+}
+
+export interface IfcCompositeCurveOnSurface {
+  type: 'IfcCompositeCurveOnSurface';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+}
+
+export interface IfcBoundaryCurve {
+  type: 'IfcBoundaryCurve';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+}
+
+export interface IfcOuterBoundaryCurve {
+  type: 'IfcOuterBoundaryCurve';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+}
+
+export interface IfcGradientCurve {
+  type: 'IfcGradientCurve';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+  baseCurve: IfcBoundedCurve;
+  endPoint?: IfcPlacement;
+}
+
+export interface IfcSegmentedReferenceCurve {
+  type: 'IfcSegmentedReferenceCurve';
+  segments: IfcSegment[];
+  selfIntersect: boolean;
+  baseCurve: IfcBoundedCurve;
+  endPoint?: IfcPlacement;
+}
+
+export interface IfcIndexedPolyCurve {
+  type: 'IfcIndexedPolyCurve';
+  points: IfcCartesianPointList;
+  segments?: number[][];
+  selfIntersect?: boolean;
+}
+
+export interface IfcPolyline {
+  type: 'IfcPolyline';
+  points: IfcCartesianPoint[];
+}
+
+export interface IfcTrimmedCurve {
+  type: 'IfcTrimmedCurve';
+  basisCurve: IfcCurve;
+  trim1: (IfcCartesianPoint | number)[];
+  trim2: (IfcCartesianPoint | number)[];
+  senseAgreement: boolean;
+  masterRepresentation: 'CARTESIAN' | 'PARAMETER' | 'UNSPECIFIED';
+}
+
+export interface IfcCircle {
+  type: 'IfcCircle';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  radius: number;
+}
+
+export interface IfcEllipse {
+  type: 'IfcEllipse';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  semiAxis1: number;
+  semiAxis2: number;
+}
+
+export interface IfcLine {
+  type: 'IfcLine';
+  pnt: IfcCartesianPoint;
+  dir: IfcVector;
+}
+
+export interface IfcOffsetCurve2D {
+  type: 'IfcOffsetCurve2D';
+  basisCurve: IfcCurve;
+  distance: number;
+  selfIntersect: boolean;
+}
+
+export interface IfcOffsetCurve3D {
+  type: 'IfcOffsetCurve3D';
+  basisCurve: IfcCurve;
+  distance: number;
+  selfIntersect: boolean;
+  refDirection: IfcDirection;
+}
+
+export interface IfcOffsetCurveByDistances {
+  type: 'IfcOffsetCurveByDistances';
+  basisCurve: IfcCurve;
+  offsetValues: IfcPointByDistanceExpression[];
+  tag?: string;
+}
+
+export interface IfcPcurve {
+  type: 'IfcPcurve';
+  basisSurface: IfcSurface;
+  referenceCurve: IfcCurve;
+}
+
+export interface IfcPolynomialCurve {
+  type: 'IfcPolynomialCurve';
+  position: IfcPlacement;
+  coefficientsX?: number[];
+  coefficientsY?: number[];
+  coefficientsZ?: number[];
+}
+
+export interface IfcClothoid {
+  type: 'IfcClothoid';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  clothoidConstant: number;
+}
+
+export interface IfcCosineSpiral {
+  type: 'IfcCosineSpiral';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  cosineTerm: number;
+  constantTerm?: number;
+}
+
+export interface IfcSecondOrderPolynomialSpiral {
+  type: 'IfcSecondOrderPolynomialSpiral';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  quadraticTerm: number;
+  linearTerm?: number;
+  constantTerm?: number;
+}
+
+export interface IfcSeventhOrderPolynomialSpiral {
+  type: 'IfcSeventhOrderPolynomialSpiral';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  septicTerm: number;
+  sexticTerm?: number;
+  quinticTerm?: number;
+  quarticTerm?: number;
+  cubicTerm?: number;
+  quadraticTerm?: number;
+  linearTerm?: number;
+  constantTerm?: number;
+}
+
+export interface IfcSineSpiral {
+  type: 'IfcSineSpiral';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  sineTerm: number;
+  linearTerm?: number;
+  constantTerm?: number;
+}
+
+export interface IfcThirdOrderPolynomialSpiral {
+  type: 'IfcThirdOrderPolynomialSpiral';
+  position: IfcAxis2Placement2D | IfcAxis2Placement3D;
+  cubicTerm: number;
+  quadraticTerm?: number;
+  linearTerm?: number;
+  constantTerm?: number;
+}
+
+export interface IfcSurfaceCurve {
+  type: 'IfcSurfaceCurve';
+  curve3D: IfcCurve;
+  associatedGeometry: IfcPcurve[];
+  masterRepresentation: 'CURVE3D' | 'PCURVE_S1' | 'PCURVE_S2';
+}
+
+export interface IfcIntersectionCurve {
+  type: 'IfcIntersectionCurve';
+  curve3D: IfcCurve;
+  associatedGeometry: IfcPcurve[];
+  masterRepresentation: 'CURVE3D' | 'PCURVE_S1' | 'PCURVE_S2';
+}
+
+export interface IfcSeamCurve {
+  type: 'IfcSeamCurve';
+  curve3D: IfcCurve;
+  associatedGeometry: IfcPcurve[];
+  masterRepresentation: 'CURVE3D' | 'PCURVE_S1' | 'PCURVE_S2';
+}
+
+export type IfcBoundedCurve =
+    IfcBSplineCurveWithKnots
+  | IfcRationalBSplineCurveWithKnots
+  | IfcCompositeCurve
+  | IfcCompositeCurveOnSurface
+  | IfcBoundaryCurve
+  | IfcOuterBoundaryCurve
+  | IfcGradientCurve
+  | IfcSegmentedReferenceCurve
+  | IfcIndexedPolyCurve
+  | IfcPolyline
+  | IfcTrimmedCurve;
+
+export type IfcCurve =
+    IfcBSplineCurveWithKnots
+  | IfcRationalBSplineCurveWithKnots
+  | IfcCompositeCurve
+  | IfcCompositeCurveOnSurface
+  | IfcBoundaryCurve
+  | IfcOuterBoundaryCurve
+  | IfcGradientCurve
+  | IfcSegmentedReferenceCurve
+  | IfcIndexedPolyCurve
+  | IfcPolyline
+  | IfcTrimmedCurve
+  | IfcCircle
+  | IfcEllipse
+  | IfcLine
+  | IfcOffsetCurve2D
+  | IfcOffsetCurve3D
+  | IfcOffsetCurveByDistances
+  | IfcPcurve
+  | IfcPolynomialCurve
+  | IfcClothoid
+  | IfcCosineSpiral
+  | IfcSecondOrderPolynomialSpiral
+  | IfcSeventhOrderPolynomialSpiral
+  | IfcSineSpiral
+  | IfcThirdOrderPolynomialSpiral
+  | IfcSurfaceCurve
+  | IfcIntersectionCurve
+  | IfcSeamCurve;
+
+/** Runtime-facing curve subset. This is intentionally narrower than
+ *  schema-complete IfcCurve until operations support every family. */
+
+export type IfcSupportedCurve =
+    IfcPolyline
+  | IfcIndexedPolyCurve
+  | IfcLine
+  | IfcCircle
+  | IfcEllipse
+  | IfcTrimmedCurve
+  | IfcCompositeCurve;
 
 // ── Parameterized profile definitions ────────────────────────────
 

--- a/src/ifc/normalize.ts
+++ b/src/ifc/normalize.ts
@@ -14,6 +14,7 @@ import type {
   IfcAreaParameterizedProfileDef,
   IfcAsymmetricIShapeProfileDef,
   IfcExtrudedAreaSolid,
+  IfcPoint,
   IfcRevolvedAreaSolid,
 } from './generated/schema.ts'
 
@@ -162,6 +163,13 @@ export function normalizePoint3(pt: IfcCartesianPoint): NormalizedVec3 {
   }
 }
 
+function requireCartesianPoint(pt: IfcPoint, context: string): IfcCartesianPoint {
+  if (pt.type !== 'IfcCartesianPoint') {
+    throw new Error(`${context} must use IfcCartesianPoint, got ${pt.type}`)
+  }
+  return pt
+}
+
 // ── Direction converters ──────────────────────────────────────────────────
 
 /** Normalize an IfcDirection to a unit 2D vector (uses directionRatios[0..1]). */
@@ -189,7 +197,7 @@ export function normalizeDirection3(
 /** Convert an IfcAxis2Placement2D to a NormalizedPlacement2D. */
 export function normalizePlacement2D(p: IfcAxis2Placement2D): NormalizedPlacement2D {
   return {
-    origin: normalizePoint2(p.location),
+    origin: normalizePoint2(requireCartesianPoint(p.location, 'IfcAxis2Placement2D.Location')),
     xAxis: p.refDirection ? normalizeDirection2(p.refDirection) : { x: 1, y: 0 },
   }
 }
@@ -204,7 +212,7 @@ export function normalizePlacement3D(p: IfcAxis2Placement3D): NormalizedPlacemen
     : { x: 1, y: 0, z: 0 }
 
   return {
-    origin: normalizePoint3(p.location),
+    origin: normalizePoint3(requireCartesianPoint(p.location, 'IfcAxis2Placement3D.Location')),
     zAxis,
     xAxis: orthogonalizeXAxis(zAxis, refDirection),
   }
@@ -237,7 +245,7 @@ export function normalizeAxis1Placement(
   const normalizedFallbackAxis = normalizeFallbackAxis3(fallbackAxis)
 
   return {
-    origin: normalizePoint3(p.location),
+    origin: normalizePoint3(requireCartesianPoint(p.location, 'IfcAxis1Placement.Location')),
     axis: p.axis
       ? normalizeDirection3(p.axis, normalizedFallbackAxis)
       : normalizedFallbackAxis,

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -1,0 +1,49 @@
+import { Color3, Mesh, MeshBuilder } from "@babylonjs/core";
+import type { Scene, StandardMaterial } from "@babylonjs/core";
+import type { IfcPolyline } from "../generated/schema.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+
+export function buildPolylineCurve(
+  scene: Scene,
+  curve: IfcPolyline,
+  name: string,
+  color = new Color3(0.2, 0.9, 0.2),
+): Mesh {
+  if (curve.points.length < 2) {
+    return new Mesh(`${name}_empty`, scene);
+  }
+
+  const points = curve.points.map((point) =>
+    ifcToBabylonVector({
+      x: point.coordinates[0] ?? 0,
+      y: point.coordinates[1] ?? 0,
+      z: point.coordinates[2] ?? 0,
+    }),
+  );
+  const lines = MeshBuilder.CreateLines(name, { points }, scene);
+  lines.color = color;
+  return lines;
+}
+
+export function buildCurvePointMarkers(
+  scene: Scene,
+  curve: IfcPolyline,
+  material: StandardMaterial,
+  name: string,
+  radius = 0.12,
+): Mesh[] {
+  return curve.points.map((point, index) => {
+    const marker = MeshBuilder.CreateSphere(
+      `${name}_${index}`,
+      { diameter: radius * 2, segments: 16 },
+      scene,
+    );
+    marker.position = ifcToBabylonVector({
+      x: point.coordinates[0] ?? 0,
+      y: point.coordinates[1] ?? 0,
+      z: point.coordinates[2] ?? 0,
+    });
+    marker.material = material;
+    return marker;
+  });
+}

--- a/src/ifc/samples/curve.polyline.ts
+++ b/src/ifc/samples/curve.polyline.ts
@@ -1,0 +1,91 @@
+import { Color3 } from "@babylonjs/core";
+import type { Scene, Mesh } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import type { IfcCartesianPoint, IfcPolyline } from "../generated/schema.ts";
+import { createSolidMaterial } from "../../engine/materials.ts";
+import { buildCurvePointMarkers, buildPolylineCurve } from "../operations/curve.ts";
+
+const DEFAULT_POLYLINE_PATH: Vec3[] = [
+  { x: -4, y: -1, z: 0 },
+  { x: -2, y: 1.5, z: 0.8 },
+  { x: 0.5, y: 0.5, z: 2.1 },
+  { x: 2.2, y: 2.5, z: 2.8 },
+  { x: 4, y: -0.5, z: 3.5 },
+];
+
+function toCartesianPoint(point: Vec3): IfcCartesianPoint {
+  return {
+    type: "IfcCartesianPoint",
+    coordinates: [point.x, point.y, point.z],
+  };
+}
+
+function toIfcPolyline(path: Vec3[]): IfcPolyline {
+  return {
+    type: "IfcPolyline",
+    points: path.map(toCartesianPoint),
+  };
+}
+
+export const curvePolylineSample: SampleDef = {
+  id: "curve-polyline",
+  title: "Polyline (IfcPolyline)",
+  description:
+    "Inspect an IfcPolyline as an ordered list of cartesian points. Edit the " +
+    "waypoints to see how the directrix used by sweep operations is represented.",
+  parameters: [],
+  steps: [
+    {
+      id: "points",
+      label: "Step 1: Cartesian Points",
+      description:
+        "IfcPolyline stores an ordered list of IfcCartesianPoint references. " +
+        "Each point contributes one vertex to the curve.",
+    },
+    {
+      id: "segments",
+      label: "Step 2: Polyline Segments",
+      description:
+        "Consecutive points are joined by straight line segments. The curve is " +
+        "open unless the final point repeats the first point.",
+    },
+  ],
+  pathEditorConfig: {
+    defaultPath: DEFAULT_POLYLINE_PATH,
+    minPoints: 2,
+    label: "IfcPolyline.Points",
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const pts = path && path.length >= 2 ? path : DEFAULT_POLYLINE_PATH;
+    const curve = toIfcPolyline(pts);
+    const markerMaterial = createSolidMaterial(scene, new Color3(1, 0.55, 0.15));
+
+    const meshes: Mesh[] = [
+      ...buildCurvePointMarkers(scene, curve, markerMaterial, "polyline_point"),
+    ];
+
+    if (stepIndex >= 1) {
+      meshes.push(buildPolylineCurve(scene, curve, "polyline_curve"));
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: () => toIfcPolyline(DEFAULT_POLYLINE_PATH),
+};

--- a/src/ifc/samples/curve.polyline.ts
+++ b/src/ifc/samples/curve.polyline.ts
@@ -10,7 +10,7 @@ import type {
   Vec3,
 } from "../../types.ts";
 import type { IfcCartesianPoint, IfcPolyline } from "../generated/schema.ts";
-import { createSolidMaterial } from "../../engine/materials.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
 import { buildCurvePointMarkers, buildPolylineCurve } from "../operations/curve.ts";
 
 const DEFAULT_POLYLINE_PATH: Vec3[] = [
@@ -75,7 +75,7 @@ export const curvePolylineSample: SampleDef = {
   ): Mesh[] => {
     const pts = path && path.length >= 2 ? path : DEFAULT_POLYLINE_PATH;
     const curve = toIfcPolyline(pts);
-    const markerMaterial = createSolidMaterial(scene, new Color3(1, 0.55, 0.15));
+    const markerMaterial = getOrCreateSolidMaterial(scene, "polyline_marker", new Color3(1, 0.55, 0.15));
 
     const meshes: Mesh[] = [
       ...buildCurvePointMarkers(scene, curve, markerMaterial, "polyline_point"),

--- a/src/style.css
+++ b/src/style.css
@@ -745,21 +745,6 @@ a.map-entity:hover {
   margin-bottom: 4px;
 }
 
-.path-preview {
-  background: #0d1b2e;
-  border: 1px solid #1a2a4a;
-  border-radius: 4px;
-  margin-bottom: 10px;
-  overflow: hidden;
-  line-height: 0;
-}
-
-.path-preview svg {
-  width: 100%;
-  height: 140px;
-  display: block;
-}
-
 .path-points-list {
   display: flex;
   flex-direction: column;

--- a/src/ui/PathEditor.ts
+++ b/src/ui/PathEditor.ts
@@ -38,13 +38,6 @@ export class PathEditor {
     const wrapper = document.createElement('div')
     wrapper.className = 'path-editor'
 
-    // SVG top-down preview
-    const preview = document.createElement('div')
-    preview.className = 'path-preview'
-    const svg = this._buildSVG()
-    preview.appendChild(svg)
-    wrapper.appendChild(preview)
-
     // Point list
     const list = document.createElement('div')
     list.className = 'path-points-list'
@@ -99,7 +92,6 @@ export class PathEditor {
         const parsed = Number(input.value)
         if (Number.isFinite(parsed)) {
           this.path[index][axis] = parsed
-          this._refreshPreview()
           this._notify()
         }
       })
@@ -127,118 +119,8 @@ export class PathEditor {
     return row
   }
 
-  // ── SVG preview (top-down XY view) ──────────────────────────────────────
-
-  private _buildSVG(): SVGSVGElement {
-    const ns = 'http://www.w3.org/2000/svg'
-    const W = 248
-    const H = 140
-    const PAD = 16
-
-    const svg = document.createElementNS(ns, 'svg')
-    svg.setAttribute('viewBox', `0 0 ${W} ${H}`)
-    svg.setAttribute('width', String(W))
-    svg.setAttribute('height', String(H))
-
-    if (this.path.length < 2) {
-      // Nothing meaningful to draw
-      const t = document.createElementNS(ns, 'text')
-      t.setAttribute('x', String(W / 2))
-      t.setAttribute('y', String(H / 2))
-      t.setAttribute('text-anchor', 'middle')
-      t.setAttribute('dominant-baseline', 'middle')
-      t.setAttribute('fill', '#4a6080')
-      t.setAttribute('font-size', '11')
-      t.textContent = 'Add at least 2 waypoints'
-      svg.appendChild(t)
-      return svg
-    }
-
-    // Compute bounding box of XY plane
-    const xs = this.path.map(p => p.x)
-    const ys = this.path.map(p => p.y)
-    const minX = Math.min(...xs)
-    const maxX = Math.max(...xs)
-    const minY = Math.min(...ys)
-    const maxY = Math.max(...ys)
-
-    const rangeX = maxX - minX || 1
-    const rangeY = maxY - minY || 1
-
-    const scaleX = (W - PAD * 2) / rangeX
-    const scaleY = (H - PAD * 2) / rangeY
-    const scale = Math.min(scaleX, scaleY)
-
-    const toSVG = (x: number, y: number): [number, number] => [
-      PAD + (x - minX) * scale + ((W - PAD * 2) - rangeX * scale) / 2,
-      H - PAD - (y - minY) * scale - ((H - PAD * 2) - rangeY * scale) / 2,
-    ]
-
-    // Axis labels
-    const labelX = document.createElementNS(ns, 'text')
-    labelX.setAttribute('x', String(W - 4))
-    labelX.setAttribute('y', String(H - 4))
-    labelX.setAttribute('text-anchor', 'end')
-    labelX.setAttribute('fill', '#ef5350')
-    labelX.setAttribute('font-size', '9')
-    labelX.textContent = 'X →'
-    svg.appendChild(labelX)
-
-    const labelY = document.createElementNS(ns, 'text')
-    labelY.setAttribute('x', '4')
-    labelY.setAttribute('y', '12')
-    labelY.setAttribute('fill', '#66bb6a')
-    labelY.setAttribute('font-size', '9')
-    labelY.textContent = '↑ Y'
-    svg.appendChild(labelY)
-
-    // Path polyline
-    const points = this.path.map(p => {
-      const [sx, sy] = toSVG(p.x, p.y)
-      return `${sx.toFixed(1)},${sy.toFixed(1)}`
-    }).join(' ')
-
-    const polyline = document.createElementNS(ns, 'polyline')
-    polyline.setAttribute('points', points)
-    polyline.setAttribute('fill', 'none')
-    polyline.setAttribute('stroke', '#4fc3f7')
-    polyline.setAttribute('stroke-width', '1.5')
-    polyline.setAttribute('stroke-linejoin', 'round')
-    polyline.setAttribute('stroke-linecap', 'round')
-    svg.appendChild(polyline)
-
-    // Waypoint dots
-    this.path.forEach((p, i) => {
-      const [sx, sy] = toSVG(p.x, p.y)
-      const circle = document.createElementNS(ns, 'circle')
-      circle.setAttribute('cx', sx.toFixed(1))
-      circle.setAttribute('cy', sy.toFixed(1))
-      circle.setAttribute('r', '3')
-      circle.setAttribute('fill', i === 0 ? '#66bb6a' : i === this.path.length - 1 ? '#ef5350' : '#4fc3f7')
-      svg.appendChild(circle)
-
-      const label = document.createElementNS(ns, 'text')
-      label.setAttribute('x', (sx + 5).toFixed(1))
-      label.setAttribute('y', (sy - 4).toFixed(1))
-      label.setAttribute('fill', '#90caf9')
-      label.setAttribute('font-size', '8')
-      label.textContent = `P${i}`
-      svg.appendChild(label)
-    })
-
-    return svg
-  }
-
   /** Full re-render (e.g. after adding/removing a point). */
   private _refresh(): void {
     this._render()
-  }
-
-  /** Only update the SVG preview without rebuilding the whole editor. */
-  private _refreshPreview(): void {
-    const preview = this.container.querySelector('.path-preview')
-    if (!preview) return
-    preview.innerHTML = ''
-    preview.appendChild(this._buildSVG())
   }
 }


### PR DESCRIPTION
## Summary

- Generate IFC curve schema metadata and TypeScript types.
- Add the first curve example for `IfcPolyline` and route it into the app.
- Remove the old path editor 2D preview UI so curve examples use the main playground flow.

## Why

This introduces the schema and app wiring needed to start implementing IFC curve entities, with `IfcPolyline` included as the first supported curve sample. Keeping this PR focused makes the generated schema changes and the initial runtime behavior easy to review before adding more curve families in follow-up work.

## Validation

- `bun run build`