### PR TITLE
[codex] Add indexed polycurve sample editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -557,9 +557,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -574,9 +571,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,9 +585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -608,9 +599,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,9 +613,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,9 +627,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,9 +641,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -676,9 +655,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,9 +669,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,9 +683,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,9 +697,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -761,9 +725,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/scripts/generate_ifc_schema.py
+++ b/scripts/generate_ifc_schema.py
@@ -97,6 +97,17 @@ OPAQUE_TS_ALIASES = {
     "IfcSurface": "unknown",
 }
 
+# IFC named type/select wrappers whose names carry runtime semantics. These
+# must not collapse to their primitive representation in TypeScript.
+TS_NAMED_ARRAY_TYPE_OVERRIDES = {
+    "IfcArcIndex": "IfcArcIndex",
+    "IfcLineIndex": "IfcLineIndex",
+}
+
+TS_SELECT_TYPE_OVERRIDES = {
+    "IfcSegmentIndexSelect": "IfcSegmentIndexSelect",
+}
+
 # ---------------------------------------------------------------------------
 # Schema resolution helpers
 # ---------------------------------------------------------------------------
@@ -312,9 +323,15 @@ def type_info_to_ts(type_info: dict) -> str:
         entity_name = type_info.get("name", "unknown")
         return TS_ENTITY_TYPE_OVERRIDES.get(entity_name, entity_name)
     if kind == "array":
+        ifc_type = type_info.get("ifcType")
+        if ifc_type in TS_NAMED_ARRAY_TYPE_OVERRIDES:
+            return TS_NAMED_ARRAY_TYPE_OVERRIDES[ifc_type]
         element_ts = type_info_to_ts(type_info.get("element", {"kind": "unknown"}))
         return f"{parenthesize_union(element_ts)}[]"
     if kind == "select":
+        ifc_type = type_info.get("ifcType")
+        if ifc_type in TS_SELECT_TYPE_OVERRIDES:
+            return TS_SELECT_TYPE_OVERRIDES[ifc_type]
         option_types: list[str] = []
         for option in type_info.get("options", []):
             if isinstance(option, dict):
@@ -398,6 +415,21 @@ def generate_ts_file(schema, profile_entities: list[str], curve_entities: list[s
     )
     for name, ts_type in OPAQUE_TS_ALIASES.items():
         blocks.append(f"export type {name} = {ts_type};")
+
+    blocks.append("// ── Indexed curve select wrappers ────────────────────────────────")
+    blocks.append(
+        "export interface IfcArcIndex {\n"
+        "  type: 'IfcArcIndex';\n"
+        "  indices: [number, number, number];\n"
+        "}"
+    )
+    blocks.append(
+        "export interface IfcLineIndex {\n"
+        "  type: 'IfcLineIndex';\n"
+        "  indices: [number, number, ...number[]];\n"
+        "}"
+    )
+    blocks.append(generate_ts_union("IfcSegmentIndexSelect", ["IfcArcIndex", "IfcLineIndex"]))
 
     # --- Curve entities --------------------------------------------------
     blocks.append("// ── Curve segment entities ────────────────────────────────────────")

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -18,10 +18,12 @@ import { extrusionZShapeSample } from "../ifc/samples/extrusion.z-shape.ts";
 import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
+import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
+  "curve-indexed-polycurve": curveIndexedPolyCurveSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -136,12 +136,14 @@ export const routes: Route[] = [
     title: "Indexed PolyCurve",
     description:
       "Represent compact line and arc segments through indexed point lists.",
+    sampleId: "curve-indexed-polycurve",
     domain: "Curves",
     difficulty: "intermediate",
     exampleKind: "primary",
-    status: "planned",
+    status: "available",
     entity: "IfcIndexedPolyCurve",
     dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
   },
   {
     hash: "#/examples/curve-circle",
@@ -466,8 +468,9 @@ export const implementationMap: ImplementationMapItem[] = [
   {
     entity: "IfcIndexedPolyCurve",
     domain: "Curves",
-    status: "planned",
+    status: "available",
     description: "Indexed curve representation for compact polyline and arc paths.",
+    routeHash: "#/examples/curve-indexed-polycurve",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/ifc/generated/schema.ts
+++ b/src/ifc/generated/schema.ts
@@ -102,6 +102,22 @@ export type IfcPlacement =
 
 export type IfcSurface = unknown;
 
+// ── Indexed curve select wrappers ────────────────────────────────
+
+export interface IfcArcIndex {
+  type: 'IfcArcIndex';
+  indices: [number, number, number];
+}
+
+export interface IfcLineIndex {
+  type: 'IfcLineIndex';
+  indices: [number, number, ...number[]];
+}
+
+export type IfcSegmentIndexSelect =
+    IfcArcIndex
+  | IfcLineIndex;
+
 // ── Curve segment entities ────────────────────────────────────────
 
 export interface IfcCompositeCurveSegment {
@@ -203,7 +219,7 @@ export interface IfcSegmentedReferenceCurve {
 export interface IfcIndexedPolyCurve {
   type: 'IfcIndexedPolyCurve';
   points: IfcCartesianPointList;
-  segments?: number[][];
+  segments?: IfcSegmentIndexSelect[];
   selfIntersect?: boolean;
 }
 

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -10,7 +10,7 @@ import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
 
 const DEFAULT_ARC_SEGMENTS = 32;
-const EPS_MINISCULE = 1e-9;
+const EPSILON = 1e-9;
 
 export type IndexedPolyCurveSegmentKind = "line" | "arc";
 
@@ -57,13 +57,13 @@ function length(v: Vec3): number {
 
 function normalize(v: Vec3): Vec3 {
   const len = length(v);
-  if (len < EPS_MINISCULE) return { x: 0, y: 0, z: 0 };
+  if (len < EPSILON) return { x: 0, y: 0, z: 0 };
   return scale(v, 1 / len);
 }
 
 function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
   const previous = points.at(-1);
-  if (!previous || !removeCoincident || distance(previous, point) > EPS_MINISCULE) {
+  if (!previous || !removeCoincident || distance(previous, point) > EPSILON) {
     points.push(point);
   }
 }
@@ -87,7 +87,7 @@ function buildArc3Point(
   const crossV = cross(v1, v2);
   const crossLen = length(crossV);
 
-  if (crossLen < EPS_MINISCULE) {
+  if (crossLen < EPSILON) {
     return [p1, p2, p3];
   }
 

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -1,7 +1,176 @@
 import { Color3, Mesh, MeshBuilder } from "@babylonjs/core";
 import type { Scene, StandardMaterial } from "@babylonjs/core";
-import type { IfcPolyline } from "../generated/schema.ts";
+import type {
+  IfcCartesianPointList,
+  IfcIndexedPolyCurve,
+  IfcPolyline,
+  IfcSegmentIndexSelect,
+} from "../generated/schema.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import type { Vec3 } from "../../types.ts";
+
+const DEFAULT_ARC_SEGMENTS = 32;
+const EPS_MINISCULE = 1e-9;
+
+export type IndexedPolyCurveSegmentKind = "line" | "arc";
+
+export interface IndexedPolyCurveResolvedSegment {
+  kind: IndexedPolyCurveSegmentKind;
+  indices: number[];
+  points: Vec3[];
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.hypot(dx, dy, dz);
+}
+
+function add(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function subtract(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function scale(v: Vec3, factor: number): Vec3 {
+  return { x: v.x * factor, y: v.y * factor, z: v.z * factor };
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function length(v: Vec3): number {
+  return Math.hypot(v.x, v.y, v.z);
+}
+
+function normalize(v: Vec3): Vec3 {
+  const len = length(v);
+  if (len < EPS_MINISCULE) return { x: 0, y: 0, z: 0 };
+  return scale(v, 1 / len);
+}
+
+function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
+  const previous = points.at(-1);
+  if (!previous || !removeCoincident || distance(previous, point) > EPS_MINISCULE) {
+    points.push(point);
+  }
+}
+
+function pointListToVec3(points: IfcCartesianPointList): Vec3[] {
+  return points.coordList.map((coords) => ({
+    x: coords[0] ?? 0,
+    y: coords[1] ?? 0,
+    z: points.type === "IfcCartesianPointList3D" ? (coords[2] ?? 0) : 0,
+  }));
+}
+
+function buildArc3Point(
+  p1: Vec3,
+  p2: Vec3,
+  p3: Vec3,
+  circleSegments = DEFAULT_ARC_SEGMENTS,
+): Vec3[] {
+  const v1 = subtract(p2, p1);
+  const v2 = subtract(p3, p1);
+  const crossV = cross(v1, v2);
+  const crossLen = length(crossV);
+
+  if (crossLen < EPS_MINISCULE) {
+    return [p1, p2, p3];
+  }
+
+  const denom = 2 * dot(crossV, crossV);
+  const centerOffset = scale(
+    add(
+      scale(cross(crossV, v1), dot(v2, v2)),
+      scale(cross(v2, crossV), dot(v1, v1)),
+    ),
+    1 / denom,
+  );
+  const center = add(p1, centerOffset);
+  const radius = distance(center, p1);
+  let pointList = [p1, p2, p3];
+
+  while (pointList.length < circleSegments) {
+    const nextPoints: Vec3[] = [];
+    for (let i = 0; i < pointList.length - 1; i++) {
+      const midPoint = scale(add(pointList[i], pointList[i + 1]), 0.5);
+      const direction = normalize(subtract(midPoint, center));
+      nextPoints.push(pointList[i], add(center, scale(direction, radius)));
+    }
+    nextPoints.push(pointList[pointList.length - 1]);
+    pointList = nextPoints;
+  }
+
+  const curve: Vec3[] = [];
+  for (const point of pointList) {
+    addCurvePoint(curve, point);
+  }
+  return curve;
+}
+
+function indexedPoints(points: Vec3[], indices: readonly number[]): Vec3[] {
+  return indices
+    .map((index) => points[index - 1])
+    .filter((point): point is Vec3 => Boolean(point));
+}
+
+function resolveIndexedPolyCurveSegment(
+  controlPoints: Vec3[],
+  segment: IfcSegmentIndexSelect,
+): IndexedPolyCurveResolvedSegment {
+  const sourcePoints = indexedPoints(controlPoints, segment.indices);
+  const kind: IndexedPolyCurveSegmentKind =
+    segment.type === "IfcArcIndex" ? "arc" : "line";
+
+  return {
+    kind,
+    indices: [...segment.indices],
+    points:
+      kind === "arc" && sourcePoints.length === 3
+        ? buildArc3Point(sourcePoints[0], sourcePoints[1], sourcePoints[2])
+        : sourcePoints,
+  };
+}
+
+export function getIndexedPolyCurveControlPoints(
+  curve: IfcIndexedPolyCurve,
+): Vec3[] {
+  return pointListToVec3(curve.points);
+}
+
+export function resolveIndexedPolyCurveSegments(
+  curve: IfcIndexedPolyCurve,
+): IndexedPolyCurveResolvedSegment[] {
+  const controlPoints = getIndexedPolyCurveControlPoints(curve);
+  const segments = curve.segments;
+
+  if (!segments || segments.length === 0) {
+    return [
+      {
+        kind: "line",
+        indices: controlPoints.map((_point, index) => index + 1),
+        points: controlPoints,
+      },
+    ];
+  }
+
+  return segments.map((segment) =>
+    resolveIndexedPolyCurveSegment(controlPoints, segment),
+  );
+}
 
 export function buildPolylineCurve(
   scene: Scene,
@@ -43,6 +212,54 @@ export function buildCurvePointMarkers(
       y: point.coordinates[1] ?? 0,
       z: point.coordinates[2] ?? 0,
     });
+    marker.material = material;
+    return marker;
+  });
+}
+
+export function buildIndexedPolyCurve(
+  scene: Scene,
+  curve: IfcIndexedPolyCurve,
+  name: string,
+  options: {
+    maxSegments?: number;
+    lineColor?: Color3;
+    arcColor?: Color3;
+  } = {},
+): Mesh[] {
+  const lineColor = options.lineColor ?? new Color3(0.2, 0.9, 0.2);
+  const arcColor = options.arcColor ?? new Color3(1, 0.55, 0.15);
+  const maxSegments = options.maxSegments ?? Number.POSITIVE_INFINITY;
+  const segments = resolveIndexedPolyCurveSegments(curve).slice(0, maxSegments);
+
+  return segments.flatMap((segment, index) => {
+    if (segment.points.length < 2) return [];
+
+    const points = segment.points.map(ifcToBabylonVector);
+    const lines = MeshBuilder.CreateLines(
+      `${name}_${segment.kind}_${index}`,
+      { points },
+      scene,
+    );
+    lines.color = segment.kind === "arc" ? arcColor : lineColor;
+    return [lines];
+  });
+}
+
+export function buildIndexedPolyCurvePointMarkers(
+  scene: Scene,
+  curve: IfcIndexedPolyCurve,
+  material: StandardMaterial,
+  name: string,
+  radius = 0.12,
+): Mesh[] {
+  return getIndexedPolyCurveControlPoints(curve).map((point, index) => {
+    const marker = MeshBuilder.CreateSphere(
+      `${name}_${index}`,
+      { diameter: radius * 2, segments: 16 },
+      scene,
+    );
+    marker.position = ifcToBabylonVector(point);
     marker.material = material;
     return marker;
   });

--- a/src/ifc/samples/curve.indexed-polycurve.ts
+++ b/src/ifc/samples/curve.indexed-polycurve.ts
@@ -1,0 +1,121 @@
+import { Color3 } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import type {
+  IfcIndexedPolyCurve,
+  IfcSegmentIndexSelect,
+} from "../generated/schema.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import {
+  buildIndexedPolyCurve,
+  buildIndexedPolyCurvePointMarkers,
+} from "../operations/curve.ts";
+
+const DEFAULT_INDEXED_POLYCURVE_POINTS: Vec3[] = [
+  { x: -4, y: -1, z: 0 },
+  { x: -2.2, y: -0.8, z: 0.3 },
+  { x: -0.7, y: 1.6, z: 1 },
+  { x: 1.1, y: 0.2, z: 1.6 },
+  { x: 2.5, y: -0.1, z: 2.4 },
+  { x: 4, y: 1.2, z: 3.1 },
+];
+
+const DEFAULT_INDEXED_POLYCURVE_SEGMENTS: IfcSegmentIndexSelect[] = [
+  { type: "IfcLineIndex" as const, indices: [1, 2] as [number, number] },
+  {
+    type: "IfcArcIndex" as const,
+    indices: [2, 3, 4] as [number, number, number],
+  },
+  {
+    type: "IfcLineIndex" as const,
+    indices: [4, 5, 6] as [number, number, ...number[]],
+  },
+];
+
+function cloneSegment(segment: IfcSegmentIndexSelect): IfcSegmentIndexSelect {
+  return segment.type === "IfcArcIndex"
+    ? { type: "IfcArcIndex", indices: [...segment.indices] }
+    : { type: "IfcLineIndex", indices: [...segment.indices] };
+}
+
+function toIfcIndexedPolyCurve(points: Vec3[]): IfcIndexedPolyCurve {
+  return {
+    type: "IfcIndexedPolyCurve",
+    points: {
+      type: "IfcCartesianPointList3D",
+      coordList: points.map((point) => [point.x, point.y, point.z]),
+    },
+    segments: DEFAULT_INDEXED_POLYCURVE_SEGMENTS.map(cloneSegment),
+    selfIntersect: false,
+  };
+}
+
+export const curveIndexedPolyCurveSample: SampleDef = {
+  id: "curve-indexed-polycurve",
+  title: "Indexed PolyCurve (IfcIndexedPolyCurve)",
+  description:
+    "Inspect an IfcIndexedPolyCurve as a compact point list with segment index " +
+    "lists for straight lines and three-point arcs.",
+  parameters: [],
+  steps: [
+    {
+      id: "point-list",
+      label: "Step 1: Points",
+      description:
+        "IfcIndexedPolyCurve stores coordinates in an IfcCartesianPointList. " +
+        "Segments refer back to these coordinates by 1-based index.",
+    },
+    {
+      id: "segments",
+      label: "Step 2: Segments",
+      description:
+        "Segments choose IfcLineIndex or IfcArcIndex and reference the point " +
+        "list by 1-based index. Lines accept two or more indices; arcs use three.",
+    },
+  ],
+  indexedPolyCurveEditorConfig: {
+    defaultCurve: toIfcIndexedPolyCurve(DEFAULT_INDEXED_POLYCURVE_POINTS),
+    label: "IfcIndexedPolyCurve",
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+    indexedPolyCurve?: IfcIndexedPolyCurve,
+  ): Mesh[] => {
+    const curve =
+      indexedPolyCurve ?? toIfcIndexedPolyCurve(DEFAULT_INDEXED_POLYCURVE_POINTS);
+    const markerMaterial = getOrCreateSolidMaterial(
+      scene,
+      "indexed_polycurve_marker",
+      new Color3(0.25, 0.55, 1),
+    );
+
+    return [
+      ...buildIndexedPolyCurvePointMarkers(
+        scene,
+        curve,
+        markerMaterial,
+        "indexed_polycurve_point",
+      ),
+      ...buildIndexedPolyCurve(scene, curve, "indexed_polycurve", {
+        maxSegments: stepIndex >= 1 ? Number.POSITIVE_INFINITY : 0,
+      }),
+    ];
+  },
+  getIFCRepresentation: () =>
+    toIfcIndexedPolyCurve(DEFAULT_INDEXED_POLYCURVE_POINTS),
+};

--- a/src/pages/ExamplePage.ts
+++ b/src/pages/ExamplePage.ts
@@ -8,6 +8,7 @@ import type {
   Vec3,
   SweepViewState,
 } from "../types.ts";
+import type { IfcIndexedPolyCurve } from "../ifc/generated/schema.ts";
 import { SceneManager } from "../engine/scene.ts";
 import { ViewportCamera } from "../engine/viewport-camera.ts";
 import { ViewportControls } from "../ui/ViewportControls.ts";
@@ -15,6 +16,7 @@ import { ParameterPanel } from "../ui/ParameterPanel.ts";
 import { Stepper } from "../ui/Stepper.ts";
 import { ProfileEditor } from "../ui/ProfileEditor.ts";
 import { PathEditor } from "../ui/PathEditor.ts";
+import { IndexedPolyCurveEditor } from "../ui/IndexedPolyCurveEditor.ts";
 import { ExtrusionEditor } from "../ui/ExtrusionEditor.ts";
 import { PlacementEditor } from "../ui/PlacementEditor.ts";
 import { SweepViewToggles } from "../ui/SweepViewToggles.ts";
@@ -31,6 +33,7 @@ export class ExamplePage {
   private currentStep = 0;
   private currentProfile: IfcProfileDef | undefined = undefined;
   private currentPath: Vec3[] | undefined = undefined;
+  private currentIndexedPolyCurve: IfcIndexedPolyCurve | undefined = undefined;
   private currentExtrusion: ExtrusionParams | undefined = undefined;
   private currentPlacement: IfcAxis2Placement3D | undefined = undefined;
   private currentSweepView: SweepViewState | undefined = undefined;
@@ -58,6 +61,12 @@ export class ExamplePage {
         ) as Vec3[])
       : undefined;
 
+    this.currentIndexedPolyCurve = sample.indexedPolyCurveEditorConfig
+      ? (JSON.parse(
+          JSON.stringify(sample.indexedPolyCurveEditorConfig.defaultCurve),
+        ) as IfcIndexedPolyCurve)
+      : undefined;
+
     // Seed extrusion from config default (if any)
     this.currentExtrusion = sample.extrusionEditorConfig
       ? (JSON.parse(
@@ -83,6 +92,7 @@ export class ExamplePage {
 
     const hasProfileEditor = Boolean(sample.profileEditorConfig);
     const hasPathEditor = Boolean(sample.pathEditorConfig);
+    const hasIndexedPolyCurveEditor = Boolean(sample.indexedPolyCurveEditorConfig);
     const hasExtrusionEditor = Boolean(sample.extrusionEditorConfig);
     const hasPlacementEditor = Boolean(sample.placementEditorConfig);
     const hasSweepToggles = Boolean(sample.sweepViewConfig);
@@ -119,9 +129,19 @@ export class ExamplePage {
                 : ""
             }
             ${
-              hasExtrusionEditor
+              hasIndexedPolyCurveEditor
                 ? `
               <details class="left-collapsible${hasProfileEditor || hasPathEditor ? " left-panel-section-mt" : ""}" open>
+                <summary class="params-title">${sample.indexedPolyCurveEditorConfig!.label ?? "Indexed PolyCurve"}</summary>
+                <div class="left-collapsible-content" id="indexed-polycurve-editor-panel"></div>
+              </details>
+            `
+                : ""
+            }
+            ${
+              hasExtrusionEditor
+                ? `
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">${sample.extrusionEditorConfig!.label ?? "Extrusion"}</summary>
                 <div class="left-collapsible-content" id="extrusion-editor-panel"></div>
               </details>
@@ -141,7 +161,7 @@ export class ExamplePage {
             ${
               sample.parameters.length > 0
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">Parameters</summary>
                 <div class="left-collapsible-content" id="param-panel"></div>
               </details>
@@ -151,7 +171,7 @@ export class ExamplePage {
             ${
               hasPlacementEditor
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
                 <summary class="params-title">${sample.placementEditorConfig!.label ?? "Placement"}</summary>
                 <div class="left-collapsible-content" id="placement-editor-panel"></div>
               </details>
@@ -208,6 +228,23 @@ export class ExamplePage {
       );
       pathEditor.onChange((path) => {
         this.currentPath = path;
+        this._scheduleRebuild(sample.debounceMs ?? 0);
+      });
+    }
+
+    const indexedPolyCurveEditorContainer = document.getElementById(
+      "indexed-polycurve-editor-panel",
+    );
+    if (
+      indexedPolyCurveEditorContainer &&
+      sample.indexedPolyCurveEditorConfig
+    ) {
+      const indexedPolyCurveEditor = new IndexedPolyCurveEditor(
+        indexedPolyCurveEditorContainer,
+        sample.indexedPolyCurveEditorConfig,
+      );
+      indexedPolyCurveEditor.onChange((curve) => {
+        this.currentIndexedPolyCurve = curve;
         this._scheduleRebuild(sample.debounceMs ?? 0);
       });
     }
@@ -308,6 +345,7 @@ export class ExamplePage {
       this.currentExtrusion,
       this.currentPlacement,
       this.currentSweepView,
+      this.currentIndexedPolyCurve,
     );
 
     // Show local coordinate axes when a placement editor is active

--- a/src/style.css
+++ b/src/style.css
@@ -779,6 +779,108 @@ a.map-entity:hover {
   border-color: #4fc3f7;
 }
 
+/* Indexed PolyCurve Editor */
+.indexed-polycurve-editor {
+  margin-bottom: 4px;
+}
+
+.indexed-polycurve-section + .indexed-polycurve-section {
+  margin-top: 10px;
+}
+
+.indexed-polycurve-section-title {
+  color: #90caf9;
+  font-size: 0.82em;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.indexed-polycurve-points-list,
+.indexed-polycurve-segments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.indexed-segment-row {
+  display: grid;
+  grid-template-columns: 24px 64px minmax(0, 1fr) 22px 22px;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78em;
+}
+
+.indexed-segment-label {
+  color: #4fc3f7;
+  font-family: monospace;
+  font-size: 0.85em;
+}
+
+.indexed-segment-type {
+  width: 64px;
+  background: #0d1b2e;
+  border: 1px solid #1a2a4a;
+  border-radius: 3px;
+  color: #c0cce0;
+  padding: 2px 4px;
+  font-size: 0.82em;
+}
+
+.indexed-segment-type:focus {
+  outline: none;
+  border-color: #4fc3f7;
+}
+
+.indexed-segment-indices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+}
+
+.indexed-segment-index-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.indexed-segment-index-input {
+  width: 42px;
+  background: #0d1b2e;
+  border: 1px solid #1a2a4a;
+  border-radius: 3px;
+  color: #c0cce0;
+  padding: 2px 4px;
+  font-size: 0.82em;
+  font-family: monospace;
+}
+
+.indexed-segment-index-input:focus {
+  outline: none;
+  border-color: #4fc3f7;
+}
+
+.indexed-segment-mini-btn,
+.indexed-segment-index-remove {
+  background: none;
+  border: 1px solid #2a4a6a;
+  border-radius: 3px;
+  color: #4fc3f7;
+  padding: 1px 5px;
+  font-size: 0.9em;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.indexed-segment-mini-btn:hover,
+.indexed-segment-index-remove:hover {
+  background: #0d2040;
+  border-color: #4fc3f7;
+}
+
 /* Extrusion Editor */
 .extrusion-editor {
   margin-bottom: 4px;

--- a/src/style.css
+++ b/src/style.css
@@ -805,6 +805,21 @@ a.map-entity:hover {
   overflow-y: auto;
 }
 
+.indexed-segment-warning {
+  background: #2b2114;
+  border: 1px solid #805c20;
+  border-radius: 4px;
+  color: #ffcc80;
+  font-size: 0.76em;
+  line-height: 1.35;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+}
+
+.indexed-segment-warning[hidden] {
+  display: none;
+}
+
 .indexed-segment-row {
   display: grid;
   grid-template-columns: 32px 64px minmax(0, 1fr) 22px 22px;
@@ -816,6 +831,11 @@ a.map-entity:hover {
   border-left: 3px solid #4fc3f7;
   border-radius: 5px;
   padding: 6px;
+}
+
+.indexed-segment-row-warning {
+  border-color: #805c20;
+  box-shadow: inset 0 0 0 1px rgba(255, 183, 77, 0.25);
 }
 
 .indexed-segment-row-line {

--- a/src/style.css
+++ b/src/style.css
@@ -806,10 +806,10 @@ a.map-entity:hover {
 }
 
 .indexed-segment-warning {
-  background: #2b2114;
-  border: 1px solid #805c20;
+  background: #2a1218;
+  border: 1px solid #8a2a3a;
   border-radius: 4px;
-  color: #ffcc80;
+  color: #ff9aa8;
   font-size: 0.76em;
   line-height: 1.35;
   margin-bottom: 6px;
@@ -834,8 +834,8 @@ a.map-entity:hover {
 }
 
 .indexed-segment-row-warning {
-  border-color: #805c20;
-  box-shadow: inset 0 0 0 1px rgba(255, 183, 77, 0.25);
+  border-color: #8a2a3a;
+  box-shadow: inset 0 0 0 1px rgba(255, 112, 136, 0.25);
 }
 
 .indexed-segment-row-line {
@@ -843,7 +843,7 @@ a.map-entity:hover {
 }
 
 .indexed-segment-row-arc {
-  border-left-color: #ffb74d;
+  border-left-color: #4fc3f7;
 }
 
 .indexed-segment-label {
@@ -857,11 +857,6 @@ a.map-entity:hover {
   font-family: monospace;
   font-size: 0.9em;
   font-weight: 600;
-}
-
-.indexed-segment-row-arc .indexed-segment-label {
-  background: #2b2114;
-  color: #ffcc80;
 }
 
 .indexed-segment-type {

--- a/src/style.css
+++ b/src/style.css
@@ -807,16 +807,41 @@ a.map-entity:hover {
 
 .indexed-segment-row {
   display: grid;
-  grid-template-columns: 24px 64px minmax(0, 1fr) 22px 22px;
+  grid-template-columns: 32px 64px minmax(0, 1fr) 22px 22px;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-size: 0.78em;
+  background: #0a1424;
+  border: 1px solid #1a2a4a;
+  border-left: 3px solid #4fc3f7;
+  border-radius: 5px;
+  padding: 6px;
+}
+
+.indexed-segment-row-line {
+  border-left-color: #4fc3f7;
+}
+
+.indexed-segment-row-arc {
+  border-left-color: #ffb74d;
 }
 
 .indexed-segment-label {
-  color: #4fc3f7;
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #10243a;
+  border-radius: 3px;
+  color: #90caf9;
   font-family: monospace;
-  font-size: 0.85em;
+  font-size: 0.9em;
+  font-weight: 600;
+}
+
+.indexed-segment-row-arc .indexed-segment-label {
+  background: #2b2114;
+  color: #ffcc80;
 }
 
 .indexed-segment-type {

--- a/src/style.css
+++ b/src/style.css
@@ -820,6 +820,16 @@ a.map-entity:hover {
   display: none;
 }
 
+.indexed-segment-empty {
+  background: #0a1424;
+  border: 1px dashed #2a4a6a;
+  border-radius: 4px;
+  color: #8fa3bd;
+  font-size: 0.76em;
+  line-height: 1.35;
+  padding: 6px 8px;
+}
+
 .indexed-segment-row {
   display: grid;
   grid-template-columns: 32px 64px minmax(0, 1fr) 22px 22px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { Scene } from "@babylonjs/core";
 import type { Mesh } from "@babylonjs/core";
 import type {
   IfcAreaParameterizedProfileDef,
+  IfcIndexedPolyCurve,
   IfcProfileTypeEnum,
 } from "./ifc/generated/schema.ts";
 
@@ -197,6 +198,14 @@ export interface PathEditorConfig {
   label?: string;
 }
 
+/** Configuration for the indexed polycurve editor widget. */
+export interface IndexedPolyCurveEditorConfig {
+  /** Initial IFC indexed polycurve, including Points and Segments. */
+  defaultCurve: IfcIndexedPolyCurve;
+  /** Optional label shown above the editor. */
+  label?: string;
+}
+
 /** Extrusion parameters edited as a single reusable unit. */
 export interface ExtrusionParams {
   /** Positive distance to extrude along extrudedDirection. */
@@ -255,6 +264,12 @@ export interface SampleDef {
    */
   pathEditorConfig?: PathEditorConfig;
   /**
+   * When set, ExamplePage renders an IndexedPolyCurveEditor widget that edits
+   * Points and Segments together. The current IfcIndexedPolyCurve is forwarded
+   * to buildGeometry as the optional ninth argument.
+   */
+  indexedPolyCurveEditorConfig?: IndexedPolyCurveEditorConfig;
+  /**
    * When set, ExamplePage renders an ExtrusionEditor widget that lets the user
    * edit depth and extrudedDirection. The current ExtrusionParams is forwarded
    * to buildGeometry as the optional sixth argument.
@@ -281,6 +296,7 @@ export interface SampleDef {
     extrusion?: ExtrusionParams,
     placement?: IfcAxis2Placement3D,
     sweepView?: SweepViewState,
+    indexedPolyCurve?: IfcIndexedPolyCurve,
   ) => Mesh[];
   getIFCRepresentation: (params: ParamValues) => object;
 }

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -277,7 +277,6 @@ export class IndexedPolyCurveEditor {
 
     const typeSelect = document.createElement("select");
     typeSelect.className = "indexed-segment-type";
-    typeSelect.value = segment.type;
     for (const option of [
       { value: "IfcLineIndex", label: "Line" },
       { value: "IfcArcIndex", label: "Arc" },
@@ -287,6 +286,7 @@ export class IndexedPolyCurveEditor {
       optionElement.textContent = option.label;
       typeSelect.appendChild(optionElement);
     }
+    typeSelect.value = segment.type;
     typeSelect.addEventListener("change", () => {
       this._setSegmentType(
         segmentIndex,

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -120,8 +120,10 @@ export class IndexedPolyCurveEditor {
 
   private _normalizeSegments(): void {
     const pointCount = this.curve.points.coordList.length;
-    this.curve.segments = (this.curve.segments ?? [makeDefaultSegment(pointCount)])
-      .map((segment) => normalizeSegment(segment, pointCount));
+    if (!this.curve.segments) return;
+    this.curve.segments = this.curve.segments.map((segment) =>
+      normalizeSegment(segment, pointCount),
+    );
   }
 
   private _notify(): void {
@@ -266,7 +268,18 @@ export class IndexedPolyCurveEditor {
   private _buildSegmentsList(): HTMLElement {
     const list = document.createElement("div");
     list.className = "indexed-polycurve-segments-list";
-    (this.curve.segments ?? []).forEach((segment, index) => {
+    const segments = this.curve.segments ?? [];
+
+    if (segments.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "indexed-segment-empty";
+      empty.textContent =
+        "Segments omitted. Points are interpreted as one line in list order.";
+      list.appendChild(empty);
+      return list;
+    }
+
+    segments.forEach((segment, index) => {
       list.appendChild(this._buildSegmentRow(segment, index));
     });
     return list;
@@ -338,21 +351,18 @@ export class IndexedPolyCurveEditor {
       row.appendChild(placeholder);
     }
 
-    if ((this.curve.segments ?? []).length > 1) {
-      const del = document.createElement("button");
-      del.className = "point-delete-btn";
-      del.title = "Remove segment";
-      del.textContent = "x";
-      del.addEventListener("click", () => {
-        this.curve.segments?.splice(segmentIndex, 1);
-        this._refreshAndNotify();
-      });
-      row.appendChild(del);
-    } else {
-      const placeholder = document.createElement("span");
-      placeholder.className = "point-delete-placeholder";
-      row.appendChild(placeholder);
-    }
+    const del = document.createElement("button");
+    del.className = "point-delete-btn";
+    del.title = "Remove segment";
+    del.textContent = "x";
+    del.addEventListener("click", () => {
+      this.curve.segments?.splice(segmentIndex, 1);
+      if (this.curve.segments?.length === 0) {
+        this.curve.segments = undefined;
+      }
+      this._refreshAndNotify();
+    });
+    row.appendChild(del);
 
     return row;
   }
@@ -409,7 +419,7 @@ export class IndexedPolyCurveEditor {
     addBtn.className = "path-add-point-btn";
     addBtn.textContent = "+ Add segment";
     addBtn.addEventListener("click", () => {
-      const segments = this.curve.segments ?? [];
+      const segments = this.curve.segments ? [...this.curve.segments] : [];
       segments.push(makeDefaultSegment(this.curve.points.coordList.length));
       this.curve.segments = segments;
       this._refreshAndNotify();

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -268,7 +268,8 @@ export class IndexedPolyCurveEditor {
     segmentIndex: number,
   ): HTMLElement {
     const row = document.createElement("div");
-    row.className = "indexed-segment-row";
+    row.className =
+      `indexed-segment-row indexed-segment-row-${segment.type === "IfcArcIndex" ? "arc" : "line"}`;
 
     const label = document.createElement("span");
     label.className = "indexed-segment-label";

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -1,0 +1,432 @@
+import type { IndexedPolyCurveEditorConfig, Vec3 } from "../types.ts";
+import type {
+  IfcArcIndex,
+  IfcIndexedPolyCurve,
+  IfcLineIndex,
+  IfcSegmentIndexSelect,
+} from "../ifc/generated/schema.ts";
+
+const DEFAULT_COORD_STEP = 0.5;
+
+function cloneSegment(segment: IfcSegmentIndexSelect): IfcSegmentIndexSelect {
+  return segment.type === "IfcArcIndex"
+    ? { type: "IfcArcIndex", indices: [...segment.indices] }
+    : { type: "IfcLineIndex", indices: [...segment.indices] };
+}
+
+function cloneCurve(curve: IfcIndexedPolyCurve): IfcIndexedPolyCurve {
+  return {
+    type: "IfcIndexedPolyCurve",
+    points: {
+      type: curve.points.type,
+      coordList: curve.points.coordList.map((coords) => [...coords]),
+      tagList: curve.points.tagList ? [...curve.points.tagList] : undefined,
+    },
+    segments: curve.segments?.map(cloneSegment),
+    selfIntersect: curve.selfIntersect,
+  };
+}
+
+function coordToVec3(coords: number[], is3D: boolean): Vec3 {
+  return {
+    x: coords[0] ?? 0,
+    y: coords[1] ?? 0,
+    z: is3D ? (coords[2] ?? 0) : 0,
+  };
+}
+
+function vec3ToCoords(point: Vec3, is3D: boolean): number[] {
+  return is3D ? [point.x, point.y, point.z] : [point.x, point.y];
+}
+
+function clampIndex(index: number, pointCount: number): number {
+  if (pointCount <= 0) return 1;
+  return Math.min(Math.max(Math.round(index), 1), pointCount);
+}
+
+function normalizeSegment(
+  segment: IfcSegmentIndexSelect,
+  pointCount: number,
+): IfcSegmentIndexSelect {
+  if (segment.type === "IfcArcIndex") {
+    const indices = [0, 1, 2].map((offset) =>
+      clampIndex(segment.indices[offset] ?? offset + 1, pointCount),
+    ) as [number, number, number];
+    return { type: "IfcArcIndex", indices };
+  }
+
+  const source =
+    segment.indices.length >= 2 ? segment.indices : [1, Math.min(2, pointCount)];
+  const indices = source.map((index) => clampIndex(index, pointCount)) as [
+    number,
+    number,
+    ...number[],
+  ];
+  return { type: "IfcLineIndex", indices };
+}
+
+function makeDefaultSegment(pointCount: number): IfcLineIndex {
+  const end = Math.max(2, pointCount);
+  return {
+    type: "IfcLineIndex",
+    indices: [Math.max(1, end - 1), end],
+  };
+}
+
+export class IndexedPolyCurveEditor {
+  private container: HTMLElement;
+  private curve: IfcIndexedPolyCurve;
+  private changeCallbacks: Array<(curve: IfcIndexedPolyCurve) => void> = [];
+
+  constructor(container: HTMLElement, config: IndexedPolyCurveEditorConfig) {
+    this.container = container;
+    this.curve = cloneCurve(config.defaultCurve);
+    this._normalizeSegments();
+    this._render();
+  }
+
+  getCurve(): IfcIndexedPolyCurve {
+    return cloneCurve(this.curve);
+  }
+
+  onChange(callback: (curve: IfcIndexedPolyCurve) => void): void {
+    this.changeCallbacks.push(callback);
+  }
+
+  private get is3D(): boolean {
+    return this.curve.points.type === "IfcCartesianPointList3D";
+  }
+
+  private get points(): Vec3[] {
+    return this.curve.points.coordList.map((coords) =>
+      coordToVec3(coords, this.is3D),
+    );
+  }
+
+  private _setPoints(points: Vec3[]): void {
+    this.curve.points.coordList = points.map((point) =>
+      vec3ToCoords(point, this.is3D),
+    );
+    this._normalizeSegments();
+  }
+
+  private _normalizeSegments(): void {
+    const pointCount = this.curve.points.coordList.length;
+    this.curve.segments = (this.curve.segments ?? [makeDefaultSegment(pointCount)])
+      .map((segment) => normalizeSegment(segment, pointCount));
+  }
+
+  private _notify(): void {
+    const copy = this.getCurve();
+    for (const cb of this.changeCallbacks) cb(copy);
+  }
+
+  private _render(): void {
+    this.container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "indexed-polycurve-editor";
+
+    const pointsSection = document.createElement("div");
+    pointsSection.className = "indexed-polycurve-section";
+    pointsSection.appendChild(this._buildSectionTitle("Points"));
+    pointsSection.appendChild(this._buildPointsList());
+    pointsSection.appendChild(this._buildAddPointButton());
+    wrapper.appendChild(pointsSection);
+
+    const segmentsSection = document.createElement("div");
+    segmentsSection.className = "indexed-polycurve-section";
+    segmentsSection.appendChild(this._buildSectionTitle("Segments"));
+    segmentsSection.appendChild(this._buildSegmentsList());
+    segmentsSection.appendChild(this._buildAddSegmentButton());
+    wrapper.appendChild(segmentsSection);
+
+    this.container.appendChild(wrapper);
+  }
+
+  private _buildSectionTitle(label: string): HTMLElement {
+    const title = document.createElement("div");
+    title.className = "indexed-polycurve-section-title";
+    title.textContent = label;
+    return title;
+  }
+
+  private _buildPointsList(): HTMLElement {
+    const list = document.createElement("div");
+    list.className = "indexed-polycurve-points-list";
+    this.points.forEach((point, index) => {
+      list.appendChild(this._buildPointRow(point, index));
+    });
+    return list;
+  }
+
+  private _buildPointRow(point: Vec3, index: number): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "path-point-row";
+
+    const idx = document.createElement("span");
+    idx.className = "point-index";
+    idx.textContent = `P${index + 1}`;
+    row.appendChild(idx);
+
+    const coords: Array<{ label: string; axis: keyof Vec3 }> = [
+      { label: "x", axis: "x" },
+      { label: "y", axis: "y" },
+      { label: "z", axis: "z" },
+    ];
+
+    for (const { label, axis } of coords) {
+      if (!this.is3D && axis === "z") continue;
+
+      const coordLabel = document.createElement("span");
+      coordLabel.className = "point-coord-label";
+      coordLabel.textContent = label;
+      row.appendChild(coordLabel);
+
+      const input = document.createElement("input");
+      input.type = "number";
+      input.className = "point-coord-input";
+      input.value = String(point[axis]);
+      input.step = String(DEFAULT_COORD_STEP);
+      input.addEventListener("input", () => {
+        const parsed = Number(input.value);
+        if (!Number.isFinite(parsed)) return;
+
+        const points = this.points;
+        points[index] = { ...points[index], [axis]: parsed };
+        this._setPoints(points);
+        this._notify();
+      });
+      row.appendChild(input);
+    }
+
+    if (this.curve.points.coordList.length > 2) {
+      const del = document.createElement("button");
+      del.className = "point-delete-btn";
+      del.title = "Remove point";
+      del.textContent = "x";
+      del.addEventListener("click", () => {
+        this._deletePoint(index);
+      });
+      row.appendChild(del);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    return row;
+  }
+
+  private _buildAddPointButton(): HTMLElement {
+    const addBtn = document.createElement("button");
+    addBtn.className = "path-add-point-btn";
+    addBtn.textContent = "+ Add point";
+    addBtn.addEventListener("click", () => {
+      const points = this.points;
+      const last = points.at(-1) ?? { x: 0, y: 0, z: 0 };
+      points.push({ x: last.x + 1, y: last.y, z: last.z });
+      this._setPoints(points);
+      this._refreshAndNotify();
+    });
+    return addBtn;
+  }
+
+  private _deletePoint(index: number): void {
+    const removedIfcIndex = index + 1;
+    const points = this.points;
+    points.splice(index, 1);
+    this.curve.points.coordList = points.map((point) =>
+      vec3ToCoords(point, this.is3D),
+    );
+
+    this.curve.segments = (this.curve.segments ?? []).map((segment) => {
+      const indices = segment.indices.map((ifcIndex) => {
+        if (ifcIndex > removedIfcIndex) return ifcIndex - 1;
+        if (ifcIndex === removedIfcIndex) return Math.min(ifcIndex, points.length);
+        return ifcIndex;
+      });
+      return normalizeSegment(
+        { type: segment.type, indices } as IfcSegmentIndexSelect,
+        points.length,
+      );
+    });
+    this._refreshAndNotify();
+  }
+
+  private _buildSegmentsList(): HTMLElement {
+    const list = document.createElement("div");
+    list.className = "indexed-polycurve-segments-list";
+    (this.curve.segments ?? []).forEach((segment, index) => {
+      list.appendChild(this._buildSegmentRow(segment, index));
+    });
+    return list;
+  }
+
+  private _buildSegmentRow(
+    segment: IfcSegmentIndexSelect,
+    segmentIndex: number,
+  ): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "indexed-segment-row";
+
+    const label = document.createElement("span");
+    label.className = "indexed-segment-label";
+    label.textContent = `S${segmentIndex + 1}`;
+    row.appendChild(label);
+
+    const typeSelect = document.createElement("select");
+    typeSelect.className = "indexed-segment-type";
+    typeSelect.value = segment.type;
+    for (const option of [
+      { value: "IfcLineIndex", label: "Line" },
+      { value: "IfcArcIndex", label: "Arc" },
+    ]) {
+      const optionElement = document.createElement("option");
+      optionElement.value = option.value;
+      optionElement.textContent = option.label;
+      typeSelect.appendChild(optionElement);
+    }
+    typeSelect.addEventListener("change", () => {
+      this._setSegmentType(
+        segmentIndex,
+        typeSelect.value === "IfcArcIndex" ? "IfcArcIndex" : "IfcLineIndex",
+      );
+    });
+    row.appendChild(typeSelect);
+
+    const indexList = document.createElement("div");
+    indexList.className = "indexed-segment-indices";
+    segment.indices.forEach((ifcIndex, indexIndex) => {
+      indexList.appendChild(
+        this._buildSegmentIndexInput(segmentIndex, indexIndex, ifcIndex),
+      );
+    });
+    row.appendChild(indexList);
+
+    if (segment.type === "IfcLineIndex") {
+      const addIndex = document.createElement("button");
+      addIndex.className = "indexed-segment-mini-btn";
+      addIndex.title = "Add line index";
+      addIndex.textContent = "+";
+      addIndex.addEventListener("click", () => {
+        const pointCount = this.curve.points.coordList.length;
+        const last = segment.indices.at(-1) ?? 1;
+        const nextIndex = clampIndex(last + 1, pointCount);
+        segment.indices.push(nextIndex);
+        this._refreshAndNotify();
+      });
+      row.appendChild(addIndex);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    if ((this.curve.segments ?? []).length > 1) {
+      const del = document.createElement("button");
+      del.className = "point-delete-btn";
+      del.title = "Remove segment";
+      del.textContent = "x";
+      del.addEventListener("click", () => {
+        this.curve.segments?.splice(segmentIndex, 1);
+        this._refreshAndNotify();
+      });
+      row.appendChild(del);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    return row;
+  }
+
+  private _buildSegmentIndexInput(
+    segmentIndex: number,
+    indexIndex: number,
+    ifcIndex: number,
+  ): HTMLElement {
+    const wrap = document.createElement("span");
+    wrap.className = "indexed-segment-index-wrap";
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = "1";
+    input.max = String(this.curve.points.coordList.length);
+    input.step = "1";
+    input.className = "indexed-segment-index-input";
+    input.value = String(ifcIndex);
+    input.addEventListener("input", () => {
+      const parsed = Number(input.value);
+      if (!Number.isFinite(parsed)) return;
+
+      const segment = this.curve.segments?.[segmentIndex];
+      if (!segment) return;
+      segment.indices[indexIndex] = clampIndex(
+        parsed,
+        this.curve.points.coordList.length,
+      );
+      this._normalizeSegments();
+      this._notify();
+    });
+    wrap.appendChild(input);
+
+    const segment = this.curve.segments?.[segmentIndex];
+    if (segment?.type === "IfcLineIndex" && segment.indices.length > 2) {
+      const remove = document.createElement("button");
+      remove.className = "indexed-segment-index-remove";
+      remove.title = "Remove line index";
+      remove.textContent = "x";
+      remove.addEventListener("click", () => {
+        segment.indices.splice(indexIndex, 1);
+        this._refreshAndNotify();
+      });
+      wrap.appendChild(remove);
+    }
+
+    return wrap;
+  }
+
+  private _buildAddSegmentButton(): HTMLElement {
+    const addBtn = document.createElement("button");
+    addBtn.className = "path-add-point-btn";
+    addBtn.textContent = "+ Add segment";
+    addBtn.addEventListener("click", () => {
+      const segments = this.curve.segments ?? [];
+      segments.push(makeDefaultSegment(this.curve.points.coordList.length));
+      this.curve.segments = segments;
+      this._refreshAndNotify();
+    });
+    return addBtn;
+  }
+
+  private _setSegmentType(
+    segmentIndex: number,
+    type: IfcArcIndex["type"] | IfcLineIndex["type"],
+  ): void {
+    const segment = this.curve.segments?.[segmentIndex];
+    if (!segment) return;
+
+    const pointCount = this.curve.points.coordList.length;
+    if (type === "IfcArcIndex") {
+      const indices = [0, 1, 2].map((offset) =>
+        clampIndex(segment.indices[offset] ?? offset + 1, pointCount),
+      ) as [number, number, number];
+      this.curve.segments![segmentIndex] = { type: "IfcArcIndex", indices };
+    } else {
+      this.curve.segments![segmentIndex] = normalizeSegment(
+        { type: "IfcLineIndex", indices: [...segment.indices] },
+        pointCount,
+      );
+    }
+
+    this._refreshAndNotify();
+  }
+
+  private _refreshAndNotify(): void {
+    this._normalizeSegments();
+    this._render();
+    this._notify();
+  }
+}

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -8,6 +8,13 @@ import type {
 
 const DEFAULT_COORD_STEP = 0.5;
 
+interface SegmentContinuityIssue {
+  previousSegmentIndex: number;
+  nextSegmentIndex: number;
+  expectedIndex: number;
+  actualIndex: number;
+}
+
 function cloneSegment(segment: IfcSegmentIndexSelect): IfcSegmentIndexSelect {
   return segment.type === "IfcArcIndex"
     ? { type: "IfcArcIndex", indices: [...segment.indices] }
@@ -77,6 +84,7 @@ export class IndexedPolyCurveEditor {
   private container: HTMLElement;
   private curve: IfcIndexedPolyCurve;
   private changeCallbacks: Array<(curve: IfcIndexedPolyCurve) => void> = [];
+  private segmentWarning: HTMLElement | undefined = undefined;
 
   constructor(container: HTMLElement, config: IndexedPolyCurveEditorConfig) {
     this.container = container;
@@ -137,6 +145,7 @@ export class IndexedPolyCurveEditor {
     const segmentsSection = document.createElement("div");
     segmentsSection.className = "indexed-polycurve-section";
     segmentsSection.appendChild(this._buildSectionTitle("Segments"));
+    segmentsSection.appendChild(this._buildSegmentWarning());
     segmentsSection.appendChild(this._buildSegmentsList());
     segmentsSection.appendChild(this._buildAddSegmentButton());
     wrapper.appendChild(segmentsSection);
@@ -268,8 +277,13 @@ export class IndexedPolyCurveEditor {
     segmentIndex: number,
   ): HTMLElement {
     const row = document.createElement("div");
-    row.className =
-      `indexed-segment-row indexed-segment-row-${segment.type === "IfcArcIndex" ? "arc" : "line"}`;
+    const hasContinuityIssue = this._hasContinuityIssue(segmentIndex);
+    row.className = "indexed-segment-row";
+    row.dataset.segmentIndex = String(segmentIndex);
+    row.classList.add(
+      `indexed-segment-row-${segment.type === "IfcArcIndex" ? "arc" : "line"}`,
+    );
+    row.classList.toggle("indexed-segment-row-warning", hasContinuityIssue);
 
     const label = document.createElement("span");
     label.className = "indexed-segment-label";
@@ -369,6 +383,7 @@ export class IndexedPolyCurveEditor {
         this.curve.points.coordList.length,
       );
       this._normalizeSegments();
+      this._syncSegmentWarning();
       this._notify();
     });
     wrap.appendChild(input);
@@ -423,6 +438,78 @@ export class IndexedPolyCurveEditor {
     }
 
     this._refreshAndNotify();
+  }
+
+  private _buildSegmentWarning(): HTMLElement {
+    this.segmentWarning = document.createElement("div");
+    this.segmentWarning.className = "indexed-segment-warning";
+    this._syncSegmentWarning();
+    return this.segmentWarning;
+  }
+
+  private _getSegmentContinuityIssues(): SegmentContinuityIssue[] {
+    const segments = this.curve.segments ?? [];
+    const issues: SegmentContinuityIssue[] = [];
+
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const current = segments[index];
+      const next = segments[index + 1];
+      const expectedIndex = current.indices.at(-1);
+      const actualIndex = next.indices[0];
+
+      if (
+        typeof expectedIndex === "number" &&
+        typeof actualIndex === "number" &&
+        expectedIndex !== actualIndex
+      ) {
+        issues.push({
+          previousSegmentIndex: index,
+          nextSegmentIndex: index + 1,
+          expectedIndex,
+          actualIndex,
+        });
+      }
+    }
+
+    return issues;
+  }
+
+  private _hasContinuityIssue(segmentIndex: number): boolean {
+    return this._getSegmentContinuityIssues().some(
+      (issue) =>
+        issue.previousSegmentIndex === segmentIndex ||
+        issue.nextSegmentIndex === segmentIndex,
+    );
+  }
+
+  private _syncSegmentWarning(): void {
+    if (!this.segmentWarning) return;
+
+    const issues = this._getSegmentContinuityIssues();
+    const issueSegmentIndices = new Set(
+      issues.flatMap((issue) => [
+        issue.previousSegmentIndex,
+        issue.nextSegmentIndex,
+      ]),
+    );
+
+    this.segmentWarning.hidden = issues.length === 0;
+    this.segmentWarning.textContent = issues
+      .map(
+        (issue) =>
+          `S${issue.previousSegmentIndex + 1} ends at P${issue.expectedIndex}, but S${issue.nextSegmentIndex + 1} starts at P${issue.actualIndex}.`,
+      )
+      .join(" ");
+
+    this.container
+      .querySelectorAll<HTMLElement>(".indexed-segment-row")
+      .forEach((row) => {
+        const segmentIndex = Number(row.dataset.segmentIndex);
+        row.classList.toggle(
+          "indexed-segment-row-warning",
+          issueSegmentIndices.has(segmentIndex),
+        );
+      });
   }
 
   private _refreshAndNotify(): void {

--- a/src/ui/IndexedPolyCurveEditor.ts
+++ b/src/ui/IndexedPolyCurveEditor.ts
@@ -215,7 +215,7 @@ export class IndexedPolyCurveEditor {
       const del = document.createElement("button");
       del.className = "point-delete-btn";
       del.title = "Remove point";
-      del.textContent = "x";
+      del.textContent = "×";
       del.addEventListener("click", () => {
         this._deletePoint(index);
       });
@@ -279,8 +279,18 @@ export class IndexedPolyCurveEditor {
       return list;
     }
 
+    const issues = this._getSegmentContinuityIssues();
+    const issueSegmentIndices = new Set(
+      issues.flatMap((issue) => [
+        issue.previousSegmentIndex,
+        issue.nextSegmentIndex,
+      ]),
+    );
+
     segments.forEach((segment, index) => {
-      list.appendChild(this._buildSegmentRow(segment, index));
+      list.appendChild(
+        this._buildSegmentRow(segment, index, issueSegmentIndices),
+      );
     });
     return list;
   }
@@ -288,9 +298,10 @@ export class IndexedPolyCurveEditor {
   private _buildSegmentRow(
     segment: IfcSegmentIndexSelect,
     segmentIndex: number,
+    issueSegmentIndices: Set<number>,
   ): HTMLElement {
     const row = document.createElement("div");
-    const hasContinuityIssue = this._hasContinuityIssue(segmentIndex);
+    const hasContinuityIssue = issueSegmentIndices.has(segmentIndex);
     row.className = "indexed-segment-row";
     row.dataset.segmentIndex = String(segmentIndex);
     row.classList.add(
@@ -354,7 +365,7 @@ export class IndexedPolyCurveEditor {
     const del = document.createElement("button");
     del.className = "point-delete-btn";
     del.title = "Remove segment";
-    del.textContent = "x";
+    del.textContent = "×";
     del.addEventListener("click", () => {
       this.curve.segments?.splice(segmentIndex, 1);
       if (this.curve.segments?.length === 0) {
@@ -388,11 +399,13 @@ export class IndexedPolyCurveEditor {
 
       const segment = this.curve.segments?.[segmentIndex];
       if (!segment) return;
-      segment.indices[indexIndex] = clampIndex(
+      const normalizedIndex = clampIndex(
         parsed,
         this.curve.points.coordList.length,
       );
+      segment.indices[indexIndex] = normalizedIndex;
       this._normalizeSegments();
+      input.value = String(segment.indices[indexIndex] ?? normalizedIndex);
       this._syncSegmentWarning();
       this._notify();
     });
@@ -403,7 +416,7 @@ export class IndexedPolyCurveEditor {
       const remove = document.createElement("button");
       remove.className = "indexed-segment-index-remove";
       remove.title = "Remove line index";
-      remove.textContent = "x";
+      remove.textContent = "×";
       remove.addEventListener("click", () => {
         segment.indices.splice(indexIndex, 1);
         this._refreshAndNotify();
@@ -482,14 +495,6 @@ export class IndexedPolyCurveEditor {
     }
 
     return issues;
-  }
-
-  private _hasContinuityIssue(segmentIndex: number): boolean {
-    return this._getSegmentContinuityIssues().some(
-      (issue) =>
-        issue.previousSegmentIndex === segmentIndex ||
-        issue.nextSegmentIndex === segmentIndex,
-    );
   }
 
   private _syncSegmentWarning(): void {


### PR DESCRIPTION
## Summary

Adds an IFC indexed polycurve sample with an interactive editor for segment definitions, warning states, and omitted-segment behavior.

## Details

- Adds generated schema support and curve operation handling for indexed polycurve segments.
- Adds a sample page route plus UI for editing points and segment ranges.
- Highlights segment warnings, nonconsecutive ranges, and omitted segment cases in the example UI.

## Validation

- `bun run build`