### PR TITLE
[codex] Add conic curve samples and trimmed-curve support

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -19,11 +19,13 @@ import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
+import { curveTrimmedSample } from "../ifc/samples/curve.trimmed.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
+  "curve-trimmed": curveTrimmedSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -19,12 +19,16 @@ import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
+import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
+import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
 import { curveTrimmedSample } from "../ifc/samples/curve.trimmed.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
+  "curve-circle": curveCircleSample,
+  "curve-ellipse": curveEllipseSample,
   "curve-trimmed": curveTrimmedSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -183,6 +183,7 @@ export const routes: Route[] = [
     status: "available",
     entity: "IfcTrimmedCurve",
     dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
   },
   {
     hash: "#/examples/profiles",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -171,6 +171,7 @@ export const routes: Route[] = [
     status: "available",
     entity: "IfcEllipse",
     dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
   },
   {
     hash: "#/examples/curve-trimmed",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -150,10 +150,11 @@ export const routes: Route[] = [
     title: "Circle",
     description:
       "Define a circular curve from an axis placement and radius.",
+    sampleId: "curve-circle",
     domain: "Curves",
     difficulty: "beginner",
     exampleKind: "primary",
-    status: "planned",
+    status: "available",
     entity: "IfcCircle",
     dependsOn: ["IfcCurve"],
   },
@@ -162,10 +163,11 @@ export const routes: Route[] = [
     title: "Ellipse",
     description:
       "Define an elliptical curve from an axis placement and two semi-axis lengths.",
+    sampleId: "curve-ellipse",
     domain: "Curves",
     difficulty: "beginner",
     exampleKind: "primary",
-    status: "planned",
+    status: "available",
     entity: "IfcEllipse",
     dependsOn: ["IfcCurve"],
   },
@@ -489,17 +491,18 @@ export const implementationMap: ImplementationMapItem[] = [
   {
     entity: "IfcCircle",
     domain: "Curves",
-    status: "partial",
-    description:
-      "Circle primitive resolved as a basis curve for trimmed-curve workflows.",
+    status: "available",
+    description: "Circle primitive positioned from an axis placement and radius.",
+    routeHash: "#/examples/curve-circle",
     dependsOn: ["IfcCurve"],
   },
   {
     entity: "IfcEllipse",
     domain: "Curves",
-    status: "partial",
+    status: "available",
     description:
-      "Ellipse primitive resolved as a basis curve for trimmed-curve workflows.",
+      "Ellipse primitive positioned from an axis placement and two semi-axis lengths.",
+    routeHash: "#/examples/curve-ellipse",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -177,7 +177,7 @@ export const routes: Route[] = [
     hash: "#/examples/curve-trimmed",
     title: "Trimmed Curve",
     description:
-      "Trim a circle or ellipse into an arc using parameter or cartesian trim selectors.",
+      "Trim a circle or ellipse into an arc using parameter-based trim selectors.",
     sampleId: "curve-trimmed",
     domain: "Curves",
     difficulty: "intermediate",

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -170,6 +170,19 @@ export const routes: Route[] = [
     dependsOn: ["IfcCurve"],
   },
   {
+    hash: "#/examples/curve-trimmed",
+    title: "Trimmed Curve",
+    description:
+      "Trim a circle or ellipse into an arc using parameter or cartesian trim selectors.",
+    sampleId: "curve-trimmed",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "primary",
+    status: "available",
+    entity: "IfcTrimmedCurve",
+    dependsOn: ["IfcCurve"],
+  },
+  {
     hash: "#/examples/profiles",
     title: "Profiles",
     description:
@@ -476,15 +489,26 @@ export const implementationMap: ImplementationMapItem[] = [
   {
     entity: "IfcCircle",
     domain: "Curves",
-    status: "planned",
-    description: "Circle curve primitive for boundaries and path-based operations.",
+    status: "partial",
+    description:
+      "Circle primitive resolved as a basis curve for trimmed-curve workflows.",
     dependsOn: ["IfcCurve"],
   },
   {
     entity: "IfcEllipse",
     domain: "Curves",
-    status: "planned",
-    description: "Ellipse curve primitive for boundaries and path-based operations.",
+    status: "partial",
+    description:
+      "Ellipse primitive resolved as a basis curve for trimmed-curve workflows.",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcTrimmedCurve",
+    domain: "Curves",
+    status: "available",
+    description:
+      "Builds visible circle and ellipse segments from basis curves plus trim selectors.",
+    routeHash: "#/examples/curve-trimmed",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -157,6 +157,7 @@ export const routes: Route[] = [
     status: "available",
     entity: "IfcCircle",
     dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
   },
   {
     hash: "#/examples/curve-ellipse",

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -9,7 +9,6 @@ import type {
   IfcLine,
   IfcPolyline,
   IfcSegmentIndexSelect,
-  IfcSupportedCurve,
   IfcTrimmedCurve,
 } from "../generated/schema.ts";
 import {
@@ -429,7 +428,7 @@ export function resolveIndexedPolyCurveSegments(
 }
 
 export function resolveSupportedCurveSegments(
-  curve: RenderableCurve | IfcSupportedCurve,
+  curve: RenderableCurve,
 ): ResolvedCurveSegment[] {
   switch (curve.type) {
     case "IfcPolyline":
@@ -459,8 +458,10 @@ export function resolveSupportedCurveSegments(
       throw new Error(
         "IfcLine is infinite and cannot be rendered without a trimming strategy",
       );
-    default:
-      throw new Error(`Curve type ${curve.type} is not supported yet`);
+    default: {
+      const _exhaustive: never = curve;
+      throw new Error(`Curve type is not supported yet: ${String(_exhaustive)}`);
+    }
   }
 }
 
@@ -511,7 +512,7 @@ export function buildCurvePointMarkers(
 
 export function buildSupportedCurve(
   scene: Scene,
-  curve: RenderableCurve | IfcSupportedCurve,
+  curve: RenderableCurve,
   name: string,
   options: {
     maxSegments?: number;

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -1,24 +1,53 @@
 import { Color3, Mesh, MeshBuilder } from "@babylonjs/core";
 import type { Scene, StandardMaterial } from "@babylonjs/core";
 import type {
+  IfcCartesianPoint,
   IfcCartesianPointList,
+  IfcCircle,
+  IfcEllipse,
   IfcIndexedPolyCurve,
+  IfcLine,
   IfcPolyline,
   IfcSegmentIndexSelect,
+  IfcSupportedCurve,
+  IfcTrimmedCurve,
 } from "../generated/schema.ts";
+import {
+  normalizePlacement2D,
+  normalizePlacement3D,
+  type NormalizedPlacement2D,
+  type NormalizedPlacement3D,
+  type NormalizedVec2,
+  type NormalizedVec3,
+} from "../normalize.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
 
 const DEFAULT_ARC_SEGMENTS = 32;
+const DEFAULT_CONIC_SEGMENTS = 64;
 const EPSILON = 1e-9;
+const FULL_CIRCLE_EPSILON = 1e-6;
 
+export type CurveSegmentKind = "line" | "arc" | "curve";
 export type IndexedPolyCurveSegmentKind = "line" | "arc";
 
-export interface IndexedPolyCurveResolvedSegment {
-  kind: IndexedPolyCurveSegmentKind;
-  indices: number[];
+export interface ResolvedCurveSegment {
+  kind: CurveSegmentKind;
   points: Vec3[];
 }
+
+export interface IndexedPolyCurveResolvedSegment extends ResolvedCurveSegment {
+  kind: IndexedPolyCurveSegmentKind;
+  indices: number[];
+}
+
+type RenderableCurve =
+  | IfcPolyline
+  | IfcIndexedPolyCurve
+  | IfcCircle
+  | IfcEllipse
+  | IfcTrimmedCurve
+  | IfcLine;
 
 function distance(a: Vec3, b: Vec3): number {
   const dx = a.x - b.x;
@@ -59,6 +88,21 @@ function normalize(v: Vec3): Vec3 {
   const len = length(v);
   if (len < EPSILON) return { x: 0, y: 0, z: 0 };
   return scale(v, 1 / len);
+}
+
+function normalizeAngle(angle: number): number {
+  const turn = Math.PI * 2;
+  let result = angle % turn;
+  if (result < 0) result += turn;
+  return result;
+}
+
+function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
 }
 
 function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
@@ -127,6 +171,218 @@ function indexedPoints(points: Vec3[], indices: readonly number[]): Vec3[] {
     .filter((point): point is Vec3 => Boolean(point));
 }
 
+function dot2(a: NormalizedVec2, b: NormalizedVec2): number {
+  return a.x * b.x + a.y * b.y;
+}
+
+function dot3Normalized(a: NormalizedVec3, b: NormalizedVec3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function cross3Normalized(
+  a: NormalizedVec3,
+  b: NormalizedVec3,
+): NormalizedVec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function pointOnPlacement2D(
+  placement: NormalizedPlacement2D,
+  point: NormalizedVec2,
+): Vec3 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z: 0,
+  };
+}
+
+function localPointOnPlacement3D(
+  placement: NormalizedPlacement3D,
+  point: NormalizedVec2,
+): Vec3 {
+  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z:
+      placement.origin.z +
+      point.x * placement.xAxis.z +
+      point.y * yAxis.z,
+  };
+}
+
+function pointToPlacement2DLocal(
+  placement: NormalizedPlacement2D,
+  point: Vec3,
+): NormalizedVec2 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  const relative = {
+    x: point.x - placement.origin.x,
+    y: point.y - placement.origin.y,
+  };
+  return {
+    x: dot2(relative, placement.xAxis),
+    y: dot2(relative, yAxis),
+  };
+}
+
+function pointToPlacement3DLocal(
+  placement: NormalizedPlacement3D,
+  point: Vec3,
+): NormalizedVec2 {
+  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
+  const relative = {
+    x: point.x - placement.origin.x,
+    y: point.y - placement.origin.y,
+    z: point.z - placement.origin.z,
+  };
+  return {
+    x: dot3Normalized(relative, placement.xAxis),
+    y: dot3Normalized(relative, yAxis),
+  };
+}
+
+function pointOnCircleOrEllipse(
+  curve: IfcCircle | IfcEllipse,
+  parameter: number,
+): Vec3 {
+  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
+  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
+  const localPoint = {
+    x: radiusX * Math.cos(parameter),
+    y: radiusY * Math.sin(parameter),
+  };
+
+  return curve.position.type === "IfcAxis2Placement2D"
+    ? pointOnPlacement2D(normalizePlacement2D(curve.position), localPoint)
+    : localPointOnPlacement3D(normalizePlacement3D(curve.position), localPoint);
+}
+
+function parameterFromCircleOrEllipsePoint(
+  curve: IfcCircle | IfcEllipse,
+  point: IfcCartesianPoint,
+): number {
+  const worldPoint = cartesianPointToVec3(point);
+  const localPoint =
+    curve.position.type === "IfcAxis2Placement2D"
+      ? pointToPlacement2DLocal(normalizePlacement2D(curve.position), worldPoint)
+      : pointToPlacement3DLocal(normalizePlacement3D(curve.position), worldPoint);
+  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
+  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
+  return Math.atan2(localPoint.y / radiusY, localPoint.x / radiusX);
+}
+
+function sampleCircleOrEllipse(
+  curve: IfcCircle | IfcEllipse,
+  startParameter: number,
+  sweep: number,
+  kind: CurveSegmentKind,
+): ResolvedCurveSegment {
+  const isClosed = Math.abs(Math.abs(sweep) - Math.PI * 2) <= FULL_CIRCLE_EPSILON;
+  const segmentCount = isClosed
+    ? DEFAULT_CONIC_SEGMENTS
+    : Math.max(
+        2,
+        Math.ceil((Math.abs(sweep) / (Math.PI * 2)) * DEFAULT_CONIC_SEGMENTS),
+      );
+  const points: Vec3[] = [];
+
+  for (let index = 0; index <= segmentCount; index += 1) {
+    const ratio = index / segmentCount;
+    addCurvePoint(
+      points,
+      pointOnCircleOrEllipse(curve, startParameter + sweep * ratio),
+      !isClosed,
+    );
+  }
+
+  return { kind, points };
+}
+
+function preferredTrimValue(
+  trim: (IfcCartesianPoint | number)[],
+  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
+): IfcCartesianPoint | number | undefined {
+  const parameterValue = trim.find((value) => typeof value === "number");
+  const cartesianValue = trim.find((value) => typeof value !== "number");
+
+  if (masterRepresentation === "CARTESIAN") {
+    return cartesianValue ?? parameterValue;
+  }
+  return parameterValue ?? cartesianValue;
+}
+
+function trimValueToParameter(
+  curve: IfcCircle | IfcEllipse,
+  trim: (IfcCartesianPoint | number)[],
+  fallback: number,
+  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
+): number {
+  const value = preferredTrimValue(trim, masterRepresentation);
+  if (typeof value === "number") {
+    return value;
+  }
+  if (value) {
+    return parameterFromCircleOrEllipsePoint(curve, value);
+  }
+  return fallback;
+}
+
+function resolveCircleOrEllipseSegment(
+  curve: IfcCircle | IfcEllipse,
+  trimmed?: Pick<
+    IfcTrimmedCurve,
+    "trim1" | "trim2" | "senseAgreement" | "masterRepresentation"
+  >,
+): ResolvedCurveSegment {
+  if (!trimmed) {
+    return sampleCircleOrEllipse(curve, 0, Math.PI * 2, "curve");
+  }
+
+  const start = normalizeAngle(
+    trimValueToParameter(
+      curve,
+      trimmed.trim1,
+      0,
+      trimmed.masterRepresentation,
+    ),
+  );
+  const end = normalizeAngle(
+    trimValueToParameter(
+      curve,
+      trimmed.trim2,
+      Math.PI * 2,
+      trimmed.masterRepresentation,
+    ),
+  );
+
+  if (trimmed.senseAgreement) {
+    const adjustedEnd = start >= end ? end + Math.PI * 2 : end;
+    return sampleCircleOrEllipse(curve, start, adjustedEnd - start, "arc");
+  }
+
+  const adjustedStart = start <= end ? start + Math.PI * 2 : start;
+  return sampleCircleOrEllipse(curve, adjustedStart, end - adjustedStart, "arc");
+}
+
 function resolveIndexedPolyCurveSegment(
   controlPoints: Vec3[],
   segment: IfcSegmentIndexSelect,
@@ -172,6 +428,42 @@ export function resolveIndexedPolyCurveSegments(
   );
 }
 
+export function resolveSupportedCurveSegments(
+  curve: RenderableCurve | IfcSupportedCurve,
+): ResolvedCurveSegment[] {
+  switch (curve.type) {
+    case "IfcPolyline":
+      return [
+        {
+          kind: "line",
+          points: curve.points.map(cartesianPointToVec3),
+        },
+      ];
+    case "IfcIndexedPolyCurve":
+      return resolveIndexedPolyCurveSegments(curve);
+    case "IfcCircle":
+      return [resolveCircleOrEllipseSegment(curve)];
+    case "IfcEllipse":
+      return [resolveCircleOrEllipseSegment(curve)];
+    case "IfcTrimmedCurve":
+      if (curve.basisCurve.type === "IfcCircle") {
+        return [resolveCircleOrEllipseSegment(curve.basisCurve, curve)];
+      }
+      if (curve.basisCurve.type === "IfcEllipse") {
+        return [resolveCircleOrEllipseSegment(curve.basisCurve, curve)];
+      }
+      throw new Error(
+        `IfcTrimmedCurve basis ${curve.basisCurve.type} is not supported yet`,
+      );
+    case "IfcLine":
+      throw new Error(
+        "IfcLine is infinite and cannot be rendered without a trimming strategy",
+      );
+    default:
+      throw new Error(`Curve type ${curve.type} is not supported yet`);
+  }
+}
+
 export function buildPolylineCurve(
   scene: Scene,
   curve: IfcPolyline,
@@ -214,6 +506,42 @@ export function buildCurvePointMarkers(
     });
     marker.material = material;
     return marker;
+  });
+}
+
+export function buildSupportedCurve(
+  scene: Scene,
+  curve: RenderableCurve | IfcSupportedCurve,
+  name: string,
+  options: {
+    maxSegments?: number;
+    lineColor?: Color3;
+    arcColor?: Color3;
+    curveColor?: Color3;
+  } = {},
+): Mesh[] {
+  const lineColor = options.lineColor ?? new Color3(0.2, 0.9, 0.2);
+  const arcColor = options.arcColor ?? new Color3(1, 0.55, 0.15);
+  const curveColor = options.curveColor ?? new Color3(0.25, 0.55, 1);
+  const maxSegments = options.maxSegments ?? Number.POSITIVE_INFINITY;
+  const segments = resolveSupportedCurveSegments(curve).slice(0, maxSegments);
+
+  return segments.flatMap((segment, index) => {
+    if (segment.points.length < 2) return [];
+
+    const points = segment.points.map(ifcToBabylonVector);
+    const lines = MeshBuilder.CreateLines(
+      `${name}_${segment.kind}_${index}`,
+      { points },
+      scene,
+    );
+    lines.color =
+      segment.kind === "line"
+        ? lineColor
+        : segment.kind === "arc"
+          ? arcColor
+          : curveColor;
+    return [lines];
   });
 }
 

--- a/src/ifc/samples/curve.circle.ts
+++ b/src/ifc/samples/curve.circle.ts
@@ -1,0 +1,125 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import { buildSupportedCurve } from "../operations/curve.ts";
+import {
+  buildIfcCircle,
+  DEFAULT_CURVE_PLACEMENT,
+  pointOnPlacement,
+} from "./curve.conic.shared.ts";
+
+function buildPlacementMarker(
+  scene: Scene,
+  placement: IfcAxis2Placement3D,
+): Mesh {
+  const marker = MeshBuilder.CreateSphere(
+    "curve_circle_center",
+    { diameter: 0.22, segments: 16 },
+    scene,
+  );
+  marker.position = ifcToBabylonVector(placement.location);
+  marker.material = getOrCreateSolidMaterial(
+    scene,
+    "curve_circle_center_material",
+    new Color3(1, 0.8, 0.2),
+  );
+  return marker;
+}
+
+function buildRadiusGuide(
+  scene: Scene,
+  placement: IfcAxis2Placement3D,
+  radius: number,
+): Mesh {
+  const guide = MeshBuilder.CreateLines(
+    "curve_circle_radius_guide",
+    {
+      points: [
+        ifcToBabylonVector(placement.location),
+        ifcToBabylonVector(pointOnPlacement(placement, { x: radius, y: 0 })),
+      ],
+    },
+    scene,
+  );
+  guide.color = new Color3(1, 0.55, 0.15);
+  return guide;
+}
+
+export const curveCircleSample: SampleDef = {
+  id: "curve-circle",
+  title: "Circle (IfcCircle)",
+  description:
+    "Inspect a standalone circular curve defined by an axis placement and radius. " +
+    "The sample reuses the same basis-curve evaluation used by IfcTrimmedCurve.",
+  parameters: [
+    {
+      key: "radius",
+      label: "Radius",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 3,
+    },
+  ],
+  steps: [
+    {
+      id: "placement",
+      label: "Step 1: Placement + Radius",
+      description:
+        "IfcCircle is positioned by IfcAxis2Placement and one radius value. " +
+        "The guide line follows the local X direction from the circle center.",
+    },
+    {
+      id: "curve",
+      label: "Step 2: Full Circle",
+      description:
+        "The full 360-degree curve is evaluated from the basis placement, which is the " +
+        "same representation later reused by IfcTrimmedCurve for circular arcs.",
+    },
+  ],
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
+    const radius = getNumber(params, "radius");
+    const curve = buildIfcCircle(radius, activePlacement);
+    const meshes: Mesh[] = [
+      buildPlacementMarker(scene, activePlacement),
+      buildRadiusGuide(scene, activePlacement, radius),
+    ];
+
+    if (stepIndex >= 1) {
+      meshes.push(
+        ...buildSupportedCurve(scene, curve, "curve_circle_result", {
+          curveColor: new Color3(0.25, 0.55, 1),
+        }),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildIfcCircle(getNumber(params, "radius"), DEFAULT_CURVE_PLACEMENT),
+};

--- a/src/ifc/samples/curve.conic.shared.ts
+++ b/src/ifc/samples/curve.conic.shared.ts
@@ -1,0 +1,119 @@
+import type { IfcAxis2Placement3D, Vec3 } from "../../types.ts";
+import type {
+  IfcAxis2Placement3D as IfcGeneratedAxis2Placement3D,
+  IfcCartesianPoint,
+  IfcCircle,
+  IfcDirection,
+  IfcEllipse,
+} from "../generated/schema.ts";
+import { normalizePlacement3D } from "../normalize.ts";
+
+export const DEFAULT_CURVE_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+
+export function toIfcDirection(direction: Vec3): IfcDirection {
+  return {
+    type: "IfcDirection",
+    directionRatios: [direction.x, direction.y, direction.z],
+  };
+}
+
+export function toIfcCurvePlacement(
+  placement: IfcAxis2Placement3D,
+): IfcGeneratedAxis2Placement3D {
+  return {
+    type: "IfcAxis2Placement3D",
+    location: {
+      type: "IfcCartesianPoint",
+      coordinates: [
+        placement.location.x,
+        placement.location.y,
+        placement.location.z,
+      ],
+    },
+    ...(placement.axis ? { axis: toIfcDirection(placement.axis) } : {}),
+    ...(placement.refDirection
+      ? { refDirection: toIfcDirection(placement.refDirection) }
+      : {}),
+  };
+}
+
+export function pointOnPlacement(
+  placement: IfcAxis2Placement3D,
+  localPoint: { x: number; y: number },
+): Vec3 {
+  const normalizedPlacement = normalizePlacement3D(toIfcCurvePlacement(placement));
+  const yAxis = {
+    x:
+      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.z -
+      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.y,
+    y:
+      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.x -
+      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.z,
+    z:
+      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.y -
+      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.x,
+  };
+
+  return {
+    x:
+      normalizedPlacement.origin.x +
+      localPoint.x * normalizedPlacement.xAxis.x +
+      localPoint.y * yAxis.x,
+    y:
+      normalizedPlacement.origin.y +
+      localPoint.x * normalizedPlacement.xAxis.y +
+      localPoint.y * yAxis.y,
+    z:
+      normalizedPlacement.origin.z +
+      localPoint.x * normalizedPlacement.xAxis.z +
+      localPoint.y * yAxis.z,
+  };
+}
+
+export function pointOnConic(
+  placement: IfcAxis2Placement3D,
+  semiAxis1: number,
+  semiAxis2: number,
+  parameter: number,
+): Vec3 {
+  return pointOnPlacement(placement, {
+    x: semiAxis1 * Math.cos(parameter),
+    y: semiAxis2 * Math.sin(parameter),
+  });
+}
+
+export function toIfcCartesianPoint(point: Vec3): IfcCartesianPoint {
+  return {
+    type: "IfcCartesianPoint",
+    coordinates: [point.x, point.y, point.z],
+  };
+}
+
+export function buildIfcCircle(
+  radius: number,
+  placement: IfcAxis2Placement3D,
+): IfcCircle {
+  return {
+    type: "IfcCircle",
+    position: toIfcCurvePlacement(placement),
+    radius,
+  };
+}
+
+export function buildIfcEllipse(
+  semiAxis1: number,
+  semiAxis2: number,
+  placement: IfcAxis2Placement3D,
+): IfcEllipse {
+  return {
+    type: "IfcEllipse",
+    position: toIfcCurvePlacement(placement),
+    semiAxis1,
+    semiAxis2,
+  };
+}

--- a/src/ifc/samples/curve.ellipse.ts
+++ b/src/ifc/samples/curve.ellipse.ts
@@ -1,0 +1,155 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import { buildSupportedCurve } from "../operations/curve.ts";
+import {
+  buildIfcEllipse,
+  DEFAULT_CURVE_PLACEMENT,
+  pointOnPlacement,
+} from "./curve.conic.shared.ts";
+
+function buildPlacementMarker(
+  scene: Scene,
+  placement: IfcAxis2Placement3D,
+): Mesh {
+  const marker = MeshBuilder.CreateSphere(
+    "curve_ellipse_center",
+    { diameter: 0.22, segments: 16 },
+    scene,
+  );
+  marker.position = ifcToBabylonVector(placement.location);
+  marker.material = getOrCreateSolidMaterial(
+    scene,
+    "curve_ellipse_center_material",
+    new Color3(1, 0.8, 0.2),
+  );
+  return marker;
+}
+
+function buildSemiAxisGuide(
+  scene: Scene,
+  placement: IfcAxis2Placement3D,
+  localTarget: { x: number; y: number },
+  name: string,
+  color: Color3,
+): Mesh {
+  const guide = MeshBuilder.CreateLines(
+    name,
+    {
+      points: [
+        ifcToBabylonVector(placement.location),
+        ifcToBabylonVector(pointOnPlacement(placement, localTarget)),
+      ],
+    },
+    scene,
+  );
+  guide.color = color;
+  return guide;
+}
+
+export const curveEllipseSample: SampleDef = {
+  id: "curve-ellipse",
+  title: "Ellipse (IfcEllipse)",
+  description:
+    "Inspect a standalone elliptical curve defined by an axis placement and two semi-axis lengths. " +
+    "This is the full basis curve used later by IfcTrimmedCurve for elliptical arcs.",
+  parameters: [
+    {
+      key: "semiAxis1",
+      label: "Semi-Axis 1",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 4,
+    },
+    {
+      key: "semiAxis2",
+      label: "Semi-Axis 2",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 2.5,
+    },
+  ],
+  steps: [
+    {
+      id: "placement",
+      label: "Step 1: Placement + Semi-Axes",
+      description:
+        "IfcEllipse uses the same placement concept as IfcCircle, but with independent lengths " +
+        "along the local X and Y directions.",
+    },
+    {
+      id: "curve",
+      label: "Step 2: Full Ellipse",
+      description:
+        "The full ellipse is sampled from the basis placement and both semi-axis lengths, " +
+        "matching the representation consumed by IfcTrimmedCurve.",
+    },
+  ],
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
+    const semiAxis1 = getNumber(params, "semiAxis1");
+    const semiAxis2 = getNumber(params, "semiAxis2");
+    const curve = buildIfcEllipse(semiAxis1, semiAxis2, activePlacement);
+
+    const meshes: Mesh[] = [
+      buildPlacementMarker(scene, activePlacement),
+      buildSemiAxisGuide(
+        scene,
+        activePlacement,
+        { x: semiAxis1, y: 0 },
+        "curve_ellipse_axis1_guide",
+        new Color3(0.25, 0.55, 1),
+      ),
+      buildSemiAxisGuide(
+        scene,
+        activePlacement,
+        { x: 0, y: semiAxis2 },
+        "curve_ellipse_axis2_guide",
+        new Color3(1, 0.55, 0.15),
+      ),
+    ];
+
+    if (stepIndex >= 1) {
+      meshes.push(
+        ...buildSupportedCurve(scene, curve, "curve_ellipse_result", {
+          curveColor: new Color3(0.35, 0.8, 0.95),
+        }),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildIfcEllipse(
+      getNumber(params, "semiAxis1"),
+      getNumber(params, "semiAxis2"),
+      DEFAULT_CURVE_PLACEMENT,
+    ),
+};

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -38,7 +38,7 @@ function buildBasisCurve(
 ): IfcCircle | IfcEllipse {
   const basis = getSelect(
     params,
-    "basis",
+    "basisCurve",
     BASIS_CURVE_OPTIONS,
     BASIS_CURVE_OPTIONS[0],
   );
@@ -162,7 +162,7 @@ export const curveTrimmedSample: SampleDef = {
     "IfcTrimmedCurve wraps IfcCircle and IfcEllipse.",
   parameters: [
     {
-      key: "basis",
+      key: "basisCurve",
       label: "Basis Curve",
       type: "select",
       options: [
@@ -170,6 +170,49 @@ export const curveTrimmedSample: SampleDef = {
         { value: "CIRCLE", label: "Circle" },
       ],
       defaultValue: "ELLIPSE",
+      group: "Basis Curve",
+    },
+    {
+      key: "radius",
+      label: "Circle Radius",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 3,
+      group: "Basis Parameters",
+      visibleWhen: {
+        key: "basisCurve",
+        equals: "CIRCLE",
+      },
+    },
+    {
+      key: "semiAxis1",
+      label: "Ellipse Semi-Axis 1",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 4,
+      group: "Basis Parameters",
+      visibleWhen: {
+        key: "basisCurve",
+        equals: "ELLIPSE",
+      },
+    },
+    {
+      key: "semiAxis2",
+      label: "Ellipse Semi-Axis 2",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 2.5,
+      group: "Basis Parameters",
+      visibleWhen: {
+        key: "basisCurve",
+        equals: "ELLIPSE",
+      },
     },
     {
       key: "trimMode",
@@ -180,6 +223,7 @@ export const curveTrimmedSample: SampleDef = {
         { value: "CARTESIAN", label: "Cartesian" },
       ],
       defaultValue: "PARAMETER",
+      group: "Trim",
     },
     {
       key: "sense",
@@ -190,33 +234,7 @@ export const curveTrimmedSample: SampleDef = {
         { value: "REVERSE", label: "Reverse" },
       ],
       defaultValue: "SAME",
-    },
-    {
-      key: "radius",
-      label: "Circle Radius",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 3,
-    },
-    {
-      key: "semiAxis1",
-      label: "Ellipse Semi-Axis 1",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 4,
-    },
-    {
-      key: "semiAxis2",
-      label: "Ellipse Semi-Axis 2",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 2.5,
+      group: "Trim",
     },
     {
       key: "startAngleDeg",
@@ -226,6 +244,7 @@ export const curveTrimmedSample: SampleDef = {
       max: 360,
       step: 1,
       defaultValue: 25,
+      group: "Trim",
     },
     {
       key: "endAngleDeg",
@@ -235,6 +254,7 @@ export const curveTrimmedSample: SampleDef = {
       max: 360,
       step: 1,
       defaultValue: 305,
+      group: "Trim",
     },
   ],
   steps: [

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -260,17 +260,17 @@ export const curveTrimmedSample: SampleDef = {
   steps: [
     {
       id: "basis-curve",
-      label: "Step 1: Basis Curve + Trim Selects",
+      label: "Step 1: Basis Curve",
       description:
-        "IfcTrimmedCurve keeps a full IfcCircle or IfcEllipse as its basisCurve. " +
-        "The trim arrays then identify where the visible segment should start and end.",
+        "IfcTrimmedCurve starts from a full IfcCircle or IfcEllipse basisCurve. " +
+        "This step shows the reusable base geometry before any trim is applied.",
     },
     {
-      id: "trimmed-result",
-      label: "Step 2: Visible Arc",
+      id: "trimmed-curve",
+      label: "Step 2: Trim",
       description:
-        "senseAgreement chooses whether the curve follows the basis parameter direction " +
-        "or the reverse direction between the two trim positions.",
+        "The trim selectors choose the start and end positions on the basis curve, and " +
+        "senseAgreement controls whether the visible segment follows the basis direction or the reverse direction.",
     },
   ],
   placementEditorConfig: {
@@ -295,11 +295,11 @@ export const curveTrimmedSample: SampleDef = {
       ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
         curveColor: new Color3(0.55, 0.6, 0.7),
       }),
-      ...buildTrimPointMarkers(scene, trimPoints),
     ];
 
     if (stepIndex >= 1) {
       meshes.push(
+        ...buildTrimPointMarkers(scene, trimPoints),
         ...buildSupportedCurve(scene, trimmedCurve, "trimmed_curve_result", {
           curveColor: new Color3(1, 0.75, 0.2),
           arcColor: new Color3(1, 0.75, 0.2),

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -11,10 +11,7 @@ import type {
 } from "../../types.ts";
 import { getNumber, getSelect } from "../../types.ts";
 import type {
-  IfcCartesianPoint,
-  IfcAxis2Placement3D as IfcGeneratedAxis2Placement3D,
   IfcCircle,
-  IfcDirection,
   IfcEllipse,
   IfcTrimmedCurve,
 } from "../generated/schema.ts";
@@ -24,96 +21,16 @@ import {
 } from "../operations/curve.ts";
 import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
-import { normalizePlacement3D } from "../normalize.ts";
-
-const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
-  type: "IfcAxis2Placement3D",
-  location: { x: 0, y: 0, z: 0 },
-  axis: { x: 0, y: 0, z: 1 },
-  refDirection: { x: 1, y: 0, z: 0 },
-};
+import {
+  buildIfcCircle,
+  buildIfcEllipse,
+  DEFAULT_CURVE_PLACEMENT,
+  pointOnConic,
+  toIfcCartesianPoint,
+} from "./curve.conic.shared.ts";
 const BASIS_CURVE_OPTIONS = ["ELLIPSE", "CIRCLE"] as const;
 const TRIM_MODE_OPTIONS = ["PARAMETER", "CARTESIAN"] as const;
 const SENSE_OPTIONS = ["SAME", "REVERSE"] as const;
-
-function toIfcDirection(direction: Vec3): IfcDirection {
-  return {
-    type: "IfcDirection",
-    directionRatios: [direction.x, direction.y, direction.z],
-  };
-}
-
-function toIfcTrimPlacement(
-  placement: IfcAxis2Placement3D,
-): IfcGeneratedAxis2Placement3D {
-  return {
-    type: "IfcAxis2Placement3D",
-    location: {
-      type: "IfcCartesianPoint",
-      coordinates: [
-        placement.location.x,
-        placement.location.y,
-        placement.location.z,
-      ],
-    },
-    ...(placement.axis ? { axis: toIfcDirection(placement.axis) } : {}),
-    ...(placement.refDirection
-      ? { refDirection: toIfcDirection(placement.refDirection) }
-      : {}),
-  };
-}
-
-function pointOnPlacement(
-  placement: IfcAxis2Placement3D,
-  localPoint: { x: number; y: number },
-): Vec3 {
-  const normalizedPlacement = normalizePlacement3D(toIfcTrimPlacement(placement));
-  const yAxis = {
-    x:
-      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.z -
-      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.y,
-    y:
-      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.x -
-      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.z,
-    z:
-      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.y -
-      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.x,
-  };
-
-  return {
-    x:
-      normalizedPlacement.origin.x +
-      localPoint.x * normalizedPlacement.xAxis.x +
-      localPoint.y * yAxis.x,
-    y:
-      normalizedPlacement.origin.y +
-      localPoint.x * normalizedPlacement.xAxis.y +
-      localPoint.y * yAxis.y,
-    z:
-      normalizedPlacement.origin.z +
-      localPoint.x * normalizedPlacement.xAxis.z +
-      localPoint.y * yAxis.z,
-  };
-}
-
-function pointOnConic(
-  placement: IfcAxis2Placement3D,
-  semiAxis1: number,
-  semiAxis2: number,
-  parameter: number,
-): Vec3 {
-  return pointOnPlacement(placement, {
-    x: semiAxis1 * Math.cos(parameter),
-    y: semiAxis2 * Math.sin(parameter),
-  });
-}
-
-function toIfcCartesianPoint(point: Vec3): IfcCartesianPoint {
-  return {
-    type: "IfcCartesianPoint",
-    coordinates: [point.x, point.y, point.z],
-  };
-}
 
 function buildBasisCurve(
   params: ParamValues,
@@ -128,22 +45,12 @@ function buildBasisCurve(
   const radius = getNumber(params, "radius");
   const semiAxis1 = getNumber(params, "semiAxis1");
   const semiAxis2 = getNumber(params, "semiAxis2");
-  const position = toIfcTrimPlacement(placement);
 
   if (basis === "CIRCLE") {
-    return {
-      type: "IfcCircle",
-      position,
-      radius,
-    };
+    return buildIfcCircle(radius, placement);
   }
 
-  return {
-    type: "IfcEllipse",
-    position,
-    semiAxis1,
-    semiAxis2,
-  };
+  return buildIfcEllipse(semiAxis1, semiAxis2, placement);
 }
 
 function buildTrimmedCurve(
@@ -347,7 +254,7 @@ export const curveTrimmedSample: SampleDef = {
     },
   ],
   placementEditorConfig: {
-    defaultPlacement: DEFAULT_PLACEMENT,
+    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
   },
   buildGeometry: (
     scene: Scene,
@@ -359,7 +266,7 @@ export const curveTrimmedSample: SampleDef = {
     placement?: IfcAxis2Placement3D,
     _sweepView?: SweepViewState,
   ): Mesh[] => {
-    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
     const { basisCurve, trimmedCurve, trimPoints } = buildTrimmedCurve(
       params,
       activePlacement,
@@ -384,5 +291,5 @@ export const curveTrimmedSample: SampleDef = {
     return meshes;
   },
   getIFCRepresentation: (params: ParamValues) =>
-    buildTrimmedCurve(params, DEFAULT_PLACEMENT).trimmedCurve,
+    buildTrimmedCurve(params, DEFAULT_CURVE_PLACEMENT).trimmedCurve,
 };

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -1,0 +1,388 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber, getSelect } from "../../types.ts";
+import type {
+  IfcCartesianPoint,
+  IfcAxis2Placement3D as IfcGeneratedAxis2Placement3D,
+  IfcCircle,
+  IfcDirection,
+  IfcEllipse,
+  IfcTrimmedCurve,
+} from "../generated/schema.ts";
+import {
+  buildSupportedCurve,
+  resolveSupportedCurveSegments,
+} from "../operations/curve.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import { normalizePlacement3D } from "../normalize.ts";
+
+const DEFAULT_PLACEMENT: IfcAxis2Placement3D = {
+  type: "IfcAxis2Placement3D",
+  location: { x: 0, y: 0, z: 0 },
+  axis: { x: 0, y: 0, z: 1 },
+  refDirection: { x: 1, y: 0, z: 0 },
+};
+const BASIS_CURVE_OPTIONS = ["ELLIPSE", "CIRCLE"] as const;
+const TRIM_MODE_OPTIONS = ["PARAMETER", "CARTESIAN"] as const;
+const SENSE_OPTIONS = ["SAME", "REVERSE"] as const;
+
+function toIfcDirection(direction: Vec3): IfcDirection {
+  return {
+    type: "IfcDirection",
+    directionRatios: [direction.x, direction.y, direction.z],
+  };
+}
+
+function toIfcTrimPlacement(
+  placement: IfcAxis2Placement3D,
+): IfcGeneratedAxis2Placement3D {
+  return {
+    type: "IfcAxis2Placement3D",
+    location: {
+      type: "IfcCartesianPoint",
+      coordinates: [
+        placement.location.x,
+        placement.location.y,
+        placement.location.z,
+      ],
+    },
+    ...(placement.axis ? { axis: toIfcDirection(placement.axis) } : {}),
+    ...(placement.refDirection
+      ? { refDirection: toIfcDirection(placement.refDirection) }
+      : {}),
+  };
+}
+
+function pointOnPlacement(
+  placement: IfcAxis2Placement3D,
+  localPoint: { x: number; y: number },
+): Vec3 {
+  const normalizedPlacement = normalizePlacement3D(toIfcTrimPlacement(placement));
+  const yAxis = {
+    x:
+      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.z -
+      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.y,
+    y:
+      normalizedPlacement.zAxis.z * normalizedPlacement.xAxis.x -
+      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.z,
+    z:
+      normalizedPlacement.zAxis.x * normalizedPlacement.xAxis.y -
+      normalizedPlacement.zAxis.y * normalizedPlacement.xAxis.x,
+  };
+
+  return {
+    x:
+      normalizedPlacement.origin.x +
+      localPoint.x * normalizedPlacement.xAxis.x +
+      localPoint.y * yAxis.x,
+    y:
+      normalizedPlacement.origin.y +
+      localPoint.x * normalizedPlacement.xAxis.y +
+      localPoint.y * yAxis.y,
+    z:
+      normalizedPlacement.origin.z +
+      localPoint.x * normalizedPlacement.xAxis.z +
+      localPoint.y * yAxis.z,
+  };
+}
+
+function pointOnConic(
+  placement: IfcAxis2Placement3D,
+  semiAxis1: number,
+  semiAxis2: number,
+  parameter: number,
+): Vec3 {
+  return pointOnPlacement(placement, {
+    x: semiAxis1 * Math.cos(parameter),
+    y: semiAxis2 * Math.sin(parameter),
+  });
+}
+
+function toIfcCartesianPoint(point: Vec3): IfcCartesianPoint {
+  return {
+    type: "IfcCartesianPoint",
+    coordinates: [point.x, point.y, point.z],
+  };
+}
+
+function buildBasisCurve(
+  params: ParamValues,
+  placement: IfcAxis2Placement3D,
+): IfcCircle | IfcEllipse {
+  const basis = getSelect(
+    params,
+    "basis",
+    BASIS_CURVE_OPTIONS,
+    BASIS_CURVE_OPTIONS[0],
+  );
+  const radius = getNumber(params, "radius");
+  const semiAxis1 = getNumber(params, "semiAxis1");
+  const semiAxis2 = getNumber(params, "semiAxis2");
+  const position = toIfcTrimPlacement(placement);
+
+  if (basis === "CIRCLE") {
+    return {
+      type: "IfcCircle",
+      position,
+      radius,
+    };
+  }
+
+  return {
+    type: "IfcEllipse",
+    position,
+    semiAxis1,
+    semiAxis2,
+  };
+}
+
+function buildTrimmedCurve(
+  params: ParamValues,
+  placement: IfcAxis2Placement3D,
+): {
+  basisCurve: IfcCircle | IfcEllipse;
+  trimmedCurve: IfcTrimmedCurve;
+  trimPoints: Vec3[];
+} {
+  const basisCurve = buildBasisCurve(params, placement);
+  const startAngle = (getNumber(params, "startAngleDeg") * Math.PI) / 180;
+  const endAngle = (getNumber(params, "endAngleDeg") * Math.PI) / 180;
+  const trimMode = getSelect(
+    params,
+    "trimMode",
+    TRIM_MODE_OPTIONS,
+    TRIM_MODE_OPTIONS[0],
+  ) as IfcTrimmedCurve["masterRepresentation"];
+  const senseAgreement =
+    getSelect(params, "sense", SENSE_OPTIONS, SENSE_OPTIONS[0]) === "SAME";
+  const semiAxis1 =
+    basisCurve.type === "IfcCircle" ? basisCurve.radius : basisCurve.semiAxis1;
+  const semiAxis2 =
+    basisCurve.type === "IfcCircle" ? basisCurve.radius : basisCurve.semiAxis2;
+  const trimPoints = [
+    pointOnConic(placement, semiAxis1, semiAxis2, startAngle),
+    pointOnConic(placement, semiAxis1, semiAxis2, endAngle),
+  ];
+
+  const trimmedCurve: IfcTrimmedCurve = {
+    type: "IfcTrimmedCurve",
+    basisCurve,
+    trim1:
+      trimMode === "CARTESIAN"
+        ? [toIfcCartesianPoint(trimPoints[0])]
+        : [startAngle],
+    trim2:
+      trimMode === "CARTESIAN"
+        ? [toIfcCartesianPoint(trimPoints[1])]
+        : [endAngle],
+    senseAgreement,
+    masterRepresentation: trimMode,
+  };
+
+  return { basisCurve, trimmedCurve, trimPoints };
+}
+
+function buildTrimPointMarkers(
+  scene: Scene,
+  trimPoints: Vec3[],
+): Mesh[] {
+  const startMaterial = getOrCreateSolidMaterial(
+    scene,
+    "trimmed_curve_start_marker",
+    new Color3(0.25, 0.55, 1),
+  );
+  const endMaterial = getOrCreateSolidMaterial(
+    scene,
+    "trimmed_curve_end_marker",
+    new Color3(1, 0.55, 0.15),
+  );
+
+  return trimPoints.map((point, index) => {
+    const marker = MeshBuilder.CreateSphere(
+      `trimmed_curve_marker_${index}`,
+      { diameter: 0.24, segments: 16 },
+      scene,
+    );
+    marker.position = ifcToBabylonVector(point);
+    marker.material = index === 0 ? startMaterial : endMaterial;
+    return marker;
+  });
+}
+
+function buildResultEndMarkers(
+  scene: Scene,
+  trimmedCurve: IfcTrimmedCurve,
+): Mesh[] {
+  const segments = resolveSupportedCurveSegments(trimmedCurve);
+  const points = segments[0]?.points ?? [];
+  if (points.length === 0) return [];
+
+  const material = getOrCreateSolidMaterial(
+    scene,
+    "trimmed_curve_result_marker",
+    new Color3(1, 0.8, 0.2),
+  );
+  const endpoints = [points[0], points[points.length - 1]];
+
+  return endpoints.map((point, index) => {
+    const marker = MeshBuilder.CreateSphere(
+      `trimmed_curve_result_endpoint_${index}`,
+      { diameter: 0.18, segments: 16 },
+      scene,
+    );
+    marker.position = ifcToBabylonVector(point);
+    marker.material = material;
+    return marker;
+  });
+}
+
+export const curveTrimmedSample: SampleDef = {
+  id: "curve-trimmed",
+  title: "Trimmed Curve (IfcTrimmedCurve)",
+  description:
+    "Build circular or elliptical arcs by trimming a reusable basis curve. " +
+    "Switch between parameter-based and cartesian trimming to inspect how " +
+    "IfcTrimmedCurve wraps IfcCircle and IfcEllipse.",
+  parameters: [
+    {
+      key: "basis",
+      label: "Basis Curve",
+      type: "select",
+      options: [
+        { value: "ELLIPSE", label: "Ellipse" },
+        { value: "CIRCLE", label: "Circle" },
+      ],
+      defaultValue: "ELLIPSE",
+    },
+    {
+      key: "trimMode",
+      label: "Trim Mode",
+      type: "select",
+      options: [
+        { value: "PARAMETER", label: "Parameter" },
+        { value: "CARTESIAN", label: "Cartesian" },
+      ],
+      defaultValue: "PARAMETER",
+    },
+    {
+      key: "sense",
+      label: "Sense",
+      type: "select",
+      options: [
+        { value: "SAME", label: "Same" },
+        { value: "REVERSE", label: "Reverse" },
+      ],
+      defaultValue: "SAME",
+    },
+    {
+      key: "radius",
+      label: "Circle Radius",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 3,
+    },
+    {
+      key: "semiAxis1",
+      label: "Ellipse Semi-Axis 1",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 4,
+    },
+    {
+      key: "semiAxis2",
+      label: "Ellipse Semi-Axis 2",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 2.5,
+    },
+    {
+      key: "startAngleDeg",
+      label: "Start Angle",
+      type: "number",
+      min: 0,
+      max: 360,
+      step: 1,
+      defaultValue: 25,
+    },
+    {
+      key: "endAngleDeg",
+      label: "End Angle",
+      type: "number",
+      min: 0,
+      max: 360,
+      step: 1,
+      defaultValue: 305,
+    },
+  ],
+  steps: [
+    {
+      id: "basis-curve",
+      label: "Step 1: Basis Curve + Trim Selects",
+      description:
+        "IfcTrimmedCurve keeps a full IfcCircle or IfcEllipse as its basisCurve. " +
+        "The trim arrays then identify where the visible segment should start and end.",
+    },
+    {
+      id: "trimmed-result",
+      label: "Step 2: Visible Arc",
+      description:
+        "senseAgreement chooses whether the curve follows the basis parameter direction " +
+        "or the reverse direction between the two trim positions.",
+    },
+  ],
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const activePlacement = placement ?? DEFAULT_PLACEMENT;
+    const { basisCurve, trimmedCurve, trimPoints } = buildTrimmedCurve(
+      params,
+      activePlacement,
+    );
+    const meshes: Mesh[] = [
+      ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
+        curveColor: new Color3(0.55, 0.6, 0.7),
+      }),
+      ...buildTrimPointMarkers(scene, trimPoints),
+    ];
+
+    if (stepIndex >= 1) {
+      meshes.push(
+        ...buildSupportedCurve(scene, trimmedCurve, "trimmed_curve_result", {
+          curveColor: new Color3(1, 0.75, 0.2),
+          arcColor: new Color3(1, 0.75, 0.2),
+        }),
+        ...buildResultEndMarkers(scene, trimmedCurve),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildTrimmedCurve(params, DEFAULT_PLACEMENT).trimmedCurve,
+};

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -1,4 +1,4 @@
-import { Color3, MeshBuilder } from "@babylonjs/core";
+import { Color3, MeshBuilder, Vector3 } from "@babylonjs/core";
 import type { Mesh, Scene } from "@babylonjs/core";
 import type {
   ExtrusionParams,
@@ -233,7 +233,7 @@ function buildDashedCurve(
       if (pointIndex === 0) return sum;
       return sum + distanceBetweenPoints(segment.points[pointIndex - 1], point);
     }, 0);
-    const lines = [];
+    const lines: Vector3[][] = [];
 
     for (
       let cursor = 0;

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -26,10 +26,8 @@ import {
   buildIfcEllipse,
   DEFAULT_CURVE_PLACEMENT,
   pointOnConic,
-  toIfcCartesianPoint,
 } from "./curve.conic.shared.ts";
 const BASIS_CURVE_OPTIONS = ["ELLIPSE", "CIRCLE"] as const;
-const TRIM_MODE_OPTIONS = ["PARAMETER", "CARTESIAN"] as const;
 const SENSE_OPTIONS = ["SAME", "REVERSE"] as const;
 
 function buildBasisCurve(
@@ -65,12 +63,6 @@ function buildTrimmedCurve(
   const basisCurve = buildBasisCurve(params, placement);
   const startAngle = (getNumber(params, "startAngleDeg") * Math.PI) / 180;
   const endAngle = (getNumber(params, "endAngleDeg") * Math.PI) / 180;
-  const trimMode = getSelect(
-    params,
-    "trimMode",
-    TRIM_MODE_OPTIONS,
-    TRIM_MODE_OPTIONS[0],
-  ) as IfcTrimmedCurve["masterRepresentation"];
   const senseAgreement =
     getSelect(params, "sense", SENSE_OPTIONS, SENSE_OPTIONS[0]) === "SAME";
   const semiAxis1 =
@@ -85,16 +77,10 @@ function buildTrimmedCurve(
   const trimmedCurve: IfcTrimmedCurve = {
     type: "IfcTrimmedCurve",
     basisCurve,
-    trim1:
-      trimMode === "CARTESIAN"
-        ? [toIfcCartesianPoint(trimPoints[0])]
-        : [startAngle],
-    trim2:
-      trimMode === "CARTESIAN"
-        ? [toIfcCartesianPoint(trimPoints[1])]
-        : [endAngle],
+    trim1: [startAngle],
+    trim2: [endAngle],
     senseAgreement,
-    masterRepresentation: trimMode,
+    masterRepresentation: "PARAMETER",
   };
 
   const remainderCurve: IfcTrimmedCurve = {
@@ -281,8 +267,7 @@ export const curveTrimmedSample: SampleDef = {
   title: "Trimmed Curve (IfcTrimmedCurve)",
   description:
     "Build circular or elliptical arcs by trimming a reusable basis curve. " +
-    "Switch between parameter-based and cartesian trimming to inspect how " +
-    "IfcTrimmedCurve wraps IfcCircle and IfcEllipse.",
+    "Inspect how IfcTrimmedCurve wraps IfcCircle and IfcEllipse using parameter-based trims.",
   parameters: [
     {
       key: "basisCurve",
@@ -336,17 +321,6 @@ export const curveTrimmedSample: SampleDef = {
         key: "basisCurve",
         equals: "ELLIPSE",
       },
-    },
-    {
-      key: "trimMode",
-      label: "Trim Mode",
-      type: "select",
-      options: [
-        { value: "PARAMETER", label: "Parameter" },
-        { value: "CARTESIAN", label: "Cartesian" },
-      ],
-      defaultValue: "PARAMETER",
-      group: "Trim",
     },
     {
       key: "sense",

--- a/src/ifc/samples/curve.trimmed.ts
+++ b/src/ifc/samples/curve.trimmed.ts
@@ -59,6 +59,7 @@ function buildTrimmedCurve(
 ): {
   basisCurve: IfcCircle | IfcEllipse;
   trimmedCurve: IfcTrimmedCurve;
+  remainderCurve: IfcTrimmedCurve;
   trimPoints: Vec3[];
 } {
   const basisCurve = buildBasisCurve(params, placement);
@@ -96,7 +97,13 @@ function buildTrimmedCurve(
     masterRepresentation: trimMode,
   };
 
-  return { basisCurve, trimmedCurve, trimPoints };
+  const remainderCurve: IfcTrimmedCurve = {
+    ...trimmedCurve,
+    trim1: trimmedCurve.trim2,
+    trim2: trimmedCurve.trim1,
+  };
+
+  return { basisCurve, trimmedCurve, remainderCurve, trimPoints };
 }
 
 function buildTrimPointMarkers(
@@ -150,6 +157,122 @@ function buildResultEndMarkers(
     marker.position = ifcToBabylonVector(point);
     marker.material = material;
     return marker;
+  });
+}
+
+function distanceBetweenPoints(a: Vec3, b: Vec3): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const dz = b.z - a.z;
+  return Math.hypot(dx, dy, dz);
+}
+
+function interpolatePoint(a: Vec3, b: Vec3, ratio: number): Vec3 {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+    z: a.z + (b.z - a.z) * ratio,
+  };
+}
+
+function extractPolylineRange(
+  points: Vec3[],
+  startDistance: number,
+  endDistance: number,
+): Vec3[] {
+  if (points.length < 2 || endDistance <= startDistance) return [];
+
+  const extracted: Vec3[] = [];
+  let traversed = 0;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const segmentStart = points[index];
+    const segmentEnd = points[index + 1];
+    const segmentLength = distanceBetweenPoints(segmentStart, segmentEnd);
+
+    if (segmentLength <= 1e-9) continue;
+
+    const localStart = Math.max(0, startDistance - traversed);
+    const localEnd = Math.min(segmentLength, endDistance - traversed);
+
+    if (localEnd > localStart) {
+      const startPoint = interpolatePoint(
+        segmentStart,
+        segmentEnd,
+        localStart / segmentLength,
+      );
+      const endPoint = interpolatePoint(
+        segmentStart,
+        segmentEnd,
+        localEnd / segmentLength,
+      );
+
+      if (extracted.length === 0) {
+        extracted.push(startPoint);
+      } else {
+        const previous = extracted[extracted.length - 1];
+        if (distanceBetweenPoints(previous, startPoint) > 1e-9) {
+          extracted.push(startPoint);
+        }
+      }
+
+      if (
+        extracted.length === 0 ||
+        distanceBetweenPoints(extracted[extracted.length - 1], endPoint) > 1e-9
+      ) {
+        extracted.push(endPoint);
+      }
+    }
+
+    traversed += segmentLength;
+    if (traversed >= endDistance) break;
+  }
+
+  return extracted;
+}
+
+function buildDashedCurve(
+  scene: Scene,
+  curve: IfcTrimmedCurve,
+  name: string,
+  color: Color3,
+): Mesh[] {
+  const segments = resolveSupportedCurveSegments(curve);
+
+  return segments.flatMap((segment, index) => {
+    if (segment.points.length < 2) return [];
+    const dashLength = 0.22;
+    const gapLength = 0.12;
+    const totalLength = segment.points.reduce((sum, point, pointIndex) => {
+      if (pointIndex === 0) return sum;
+      return sum + distanceBetweenPoints(segment.points[pointIndex - 1], point);
+    }, 0);
+    const lines = [];
+
+    for (
+      let cursor = 0;
+      cursor < totalLength;
+      cursor += dashLength + gapLength
+    ) {
+      const dashPoints = extractPolylineRange(
+        segment.points,
+        cursor,
+        Math.min(cursor + dashLength, totalLength),
+      );
+      if (dashPoints.length >= 2) {
+        lines.push(dashPoints.map(ifcToBabylonVector));
+      }
+    }
+
+    if (lines.length === 0) return [];
+
+    const dashed = MeshBuilder.CreateLineSystem(
+      `${name}_${index}`,
+      { lines },
+      scene,
+    );
+    dashed.color = color;
+    return [dashed];
   });
 }
 
@@ -287,19 +410,28 @@ export const curveTrimmedSample: SampleDef = {
     _sweepView?: SweepViewState,
   ): Mesh[] => {
     const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
-    const { basisCurve, trimmedCurve, trimPoints } = buildTrimmedCurve(
+    const { basisCurve, trimmedCurve, remainderCurve, trimPoints } = buildTrimmedCurve(
       params,
       activePlacement,
     );
-    const meshes: Mesh[] = [
-      ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
-        curveColor: new Color3(0.55, 0.6, 0.7),
-      }),
-    ];
+    const meshes: Mesh[] =
+      stepIndex === 0
+        ? [
+            ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
+              curveColor: new Color3(0.55, 0.6, 0.7),
+            }),
+          ]
+        : [];
 
     if (stepIndex >= 1) {
       meshes.push(
         ...buildTrimPointMarkers(scene, trimPoints),
+        ...buildDashedCurve(
+          scene,
+          remainderCurve,
+          "trimmed_curve_remainder",
+          new Color3(0.42, 0.46, 0.54),
+        ),
         ...buildSupportedCurve(scene, trimmedCurve, "trimmed_curve_result", {
           curveColor: new Color3(1, 0.75, 0.2),
           arcColor: new Color3(1, 0.75, 0.2),

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,7 @@ export interface NumberParameterDef {
   group?: string;
   visibleWhen?: {
     key: string;
-    equals: string | number;
+    equals: string;
   };
 }
 
@@ -136,7 +136,7 @@ export interface SelectParameterDef {
   group?: string;
   visibleWhen?: {
     key: string;
-    equals: string | number;
+    equals: string;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,11 @@ export interface NumberParameterDef {
   max: number;
   step: number;
   defaultValue: number;
+  group?: string;
+  visibleWhen?: {
+    key: string;
+    equals: string | number;
+  };
 }
 
 export interface SelectOption {
@@ -128,6 +133,11 @@ export interface SelectParameterDef {
   type: "select";
   options: SelectOption[];
   defaultValue: string;
+  group?: string;
+  visibleWhen?: {
+    key: string;
+    equals: string | number;
+  };
 }
 
 export type ParameterDef = NumberParameterDef | SelectParameterDef;

--- a/src/ui/ParameterPanel.ts
+++ b/src/ui/ParameterPanel.ts
@@ -21,7 +21,24 @@ export class ParameterPanel {
 
   private _render() {
     this.container.innerHTML = ''
+    let currentGroup: string | undefined
+
     for (const param of this.sample.parameters) {
+      if (
+        param.visibleWhen &&
+        this.values[param.visibleWhen.key] !== param.visibleWhen.equals
+      ) {
+        continue
+      }
+
+      if (param.group && param.group !== currentGroup) {
+        currentGroup = param.group
+        const heading = document.createElement('div')
+        heading.className = 'param-label'
+        heading.textContent = param.group
+        this.container.appendChild(heading)
+      }
+
       const group = document.createElement('div')
       group.className = 'param-group'
 
@@ -76,6 +93,7 @@ export class ParameterPanel {
 
         select.addEventListener('change', () => {
           this.values[param.key] = select.value
+          this._render()
           this._notifyChange()
         })
 


### PR DESCRIPTION
## What changed
- added shared conic curve support in `src/ifc/operations/curve.ts` for `IfcCircle`, `IfcEllipse`, and `IfcTrimmedCurve`
- added standalone `IfcCircle` and `IfcEllipse` samples plus a shared conic sample helper
- added a `Trimmed Curve` sample that demonstrates basis curves, parameter trims, trim direction, and a clearer dashed remainder visualization
- updated routes and sample registration so the new curve cards appear in the playground
- extended the parameter panel with lightweight grouping and conditional visibility so basis-specific parameters switch with the selected basis curve

## Why
`IfcCircle` and `IfcEllipse` are most useful here as basis curves for `IfcTrimmedCurve`, but they also benefit from standalone cards for exploration and debugging. This PR adds the common evaluation layer first, then uses it to expose circular and elliptical trimmed curves in a way that is easier to understand visually.

## Impact
- `IfcCircle`, `IfcEllipse`, and `IfcTrimmedCurve` are now available in the curve examples
- the trimmed-curve UI now matches current support by exposing parameter-based trims only
- trimmed ellipse remainder rendering no longer drops dashed segments partway through the curve

## Validation
- `npm run build`
