### PR TITLE
[codex] Split trimmed curve basis handling

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -21,7 +21,8 @@ import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
 import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
 import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
-import { curveTrimmedSample } from "../ifc/samples/curve.trimmed.ts";
+import { curveTrimmedCircleSample } from "../ifc/samples/curve.trimmed-circle.ts";
+import { curveTrimmedEllipseSample } from "../ifc/samples/curve.trimmed-ellipse.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
@@ -29,7 +30,8 @@ const samples: Record<string, SampleDef> = {
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
   "curve-circle": curveCircleSample,
   "curve-ellipse": curveEllipseSample,
-  "curve-trimmed": curveTrimmedSample,
+  "curve-trimmed-circle": curveTrimmedCircleSample,
+  "curve-trimmed-ellipse": curveTrimmedEllipseSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -174,17 +174,31 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
-    hash: "#/examples/curve-trimmed",
-    title: "Trimmed Curve",
+    hash: "#/examples/curve-trimmed-circle",
+    title: "Trimmed Circle",
     description:
-      "Trim a circle or ellipse into an arc using parameter-based trim selectors.",
-    sampleId: "curve-trimmed",
+      "Trim an IfcCircle basis curve into a circular arc using parameter-based selectors.",
+    sampleId: "curve-trimmed-circle",
     domain: "Curves",
     difficulty: "intermediate",
-    exampleKind: "primary",
+    exampleKind: "variant",
     status: "available",
     entity: "IfcTrimmedCurve",
-    dependsOn: ["IfcCurve"],
+    dependsOn: ["IfcCurve", "IfcCircle"],
+    operationGroup: "curve-primitives",
+  },
+  {
+    hash: "#/examples/curve-trimmed-ellipse",
+    title: "Trimmed Ellipse",
+    description:
+      "Trim an IfcEllipse basis curve into an elliptical arc using parameter-based selectors.",
+    sampleId: "curve-trimmed-ellipse",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "variant",
+    status: "available",
+    entity: "IfcTrimmedCurve",
+    dependsOn: ["IfcCurve", "IfcEllipse"],
     operationGroup: "curve-primitives",
   },
   {
@@ -513,8 +527,8 @@ export const implementationMap: ImplementationMapItem[] = [
     domain: "Curves",
     status: "available",
     description:
-      "Builds visible circle and ellipse segments from basis curves plus trim selectors.",
-    routeHash: "#/examples/curve-trimmed",
+      "Builds visible curve segments from basis curves plus trim selectors, with basis-specific examples.",
+    routeHash: "#/examples/curve-trimmed-circle",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/ifc/operations/curve-conic.ts
+++ b/src/ifc/operations/curve-conic.ts
@@ -1,0 +1,261 @@
+import type {
+  IfcCartesianPoint,
+  IfcCircle,
+  IfcEllipse,
+  IfcTrimmedCurve,
+} from "../generated/schema.ts";
+import {
+  normalizePlacement2D,
+  normalizePlacement3D,
+  type NormalizedPlacement2D,
+  type NormalizedPlacement3D,
+  type NormalizedVec2,
+  type NormalizedVec3,
+} from "../normalize.ts";
+import type { Vec3 } from "../../types.ts";
+import type { CurveSegmentKind, ResolvedCurveSegment } from "./curve-types.ts";
+
+const DEFAULT_CONIC_SEGMENTS = 64;
+const EPSILON = 1e-9;
+const FULL_CIRCLE_EPSILON = 1e-6;
+
+type ConicCurve = IfcCircle | IfcEllipse;
+type TrimmedCurveParameters = Pick<
+  IfcTrimmedCurve,
+  "trim1" | "trim2" | "senseAgreement" | "masterRepresentation"
+>;
+
+function distance(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.hypot(dx, dy, dz);
+}
+
+function normalizeAngle(angle: number): number {
+  const turn = Math.PI * 2;
+  let result = angle % turn;
+  if (result < 0) result += turn;
+  return result;
+}
+
+function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
+}
+
+function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
+  const previous = points.at(-1);
+  if (!previous || !removeCoincident || distance(previous, point) > EPSILON) {
+    points.push(point);
+  }
+}
+
+function dot2(a: NormalizedVec2, b: NormalizedVec2): number {
+  return a.x * b.x + a.y * b.y;
+}
+
+function dot3Normalized(a: NormalizedVec3, b: NormalizedVec3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+function cross3Normalized(
+  a: NormalizedVec3,
+  b: NormalizedVec3,
+): NormalizedVec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function pointOnPlacement2D(
+  placement: NormalizedPlacement2D,
+  point: NormalizedVec2,
+): Vec3 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z: 0,
+  };
+}
+
+function localPointOnPlacement3D(
+  placement: NormalizedPlacement3D,
+  point: NormalizedVec2,
+): Vec3 {
+  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z:
+      placement.origin.z +
+      point.x * placement.xAxis.z +
+      point.y * yAxis.z,
+  };
+}
+
+function pointToPlacement2DLocal(
+  placement: NormalizedPlacement2D,
+  point: Vec3,
+): NormalizedVec2 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  const relative = {
+    x: point.x - placement.origin.x,
+    y: point.y - placement.origin.y,
+  };
+  return {
+    x: dot2(relative, placement.xAxis),
+    y: dot2(relative, yAxis),
+  };
+}
+
+function pointToPlacement3DLocal(
+  placement: NormalizedPlacement3D,
+  point: Vec3,
+): NormalizedVec2 {
+  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
+  const relative = {
+    x: point.x - placement.origin.x,
+    y: point.y - placement.origin.y,
+    z: point.z - placement.origin.z,
+  };
+  return {
+    x: dot3Normalized(relative, placement.xAxis),
+    y: dot3Normalized(relative, yAxis),
+  };
+}
+
+function pointOnConic(curve: ConicCurve, parameter: number): Vec3 {
+  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
+  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
+  const localPoint = {
+    x: radiusX * Math.cos(parameter),
+    y: radiusY * Math.sin(parameter),
+  };
+
+  return curve.position.type === "IfcAxis2Placement2D"
+    ? pointOnPlacement2D(normalizePlacement2D(curve.position), localPoint)
+    : localPointOnPlacement3D(normalizePlacement3D(curve.position), localPoint);
+}
+
+function parameterFromConicPoint(
+  curve: ConicCurve,
+  point: IfcCartesianPoint,
+): number {
+  const worldPoint = cartesianPointToVec3(point);
+  const localPoint =
+    curve.position.type === "IfcAxis2Placement2D"
+      ? pointToPlacement2DLocal(normalizePlacement2D(curve.position), worldPoint)
+      : pointToPlacement3DLocal(normalizePlacement3D(curve.position), worldPoint);
+  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
+  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
+  return Math.atan2(localPoint.y / radiusY, localPoint.x / radiusX);
+}
+
+function sampleConic(
+  curve: ConicCurve,
+  startParameter: number,
+  sweep: number,
+  kind: CurveSegmentKind,
+): ResolvedCurveSegment {
+  const isClosed = Math.abs(Math.abs(sweep) - Math.PI * 2) <= FULL_CIRCLE_EPSILON;
+  const segmentCount = isClosed
+    ? DEFAULT_CONIC_SEGMENTS
+    : Math.max(
+        2,
+        Math.ceil((Math.abs(sweep) / (Math.PI * 2)) * DEFAULT_CONIC_SEGMENTS),
+      );
+  const points: Vec3[] = [];
+
+  for (let index = 0; index <= segmentCount; index += 1) {
+    const ratio = index / segmentCount;
+    addCurvePoint(
+      points,
+      pointOnConic(curve, startParameter + sweep * ratio),
+      !isClosed,
+    );
+  }
+
+  return { kind, points };
+}
+
+function preferredTrimValue(
+  trim: (IfcCartesianPoint | number)[],
+  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
+): IfcCartesianPoint | number | undefined {
+  const parameterValue = trim.find((value) => typeof value === "number");
+  const cartesianValue = trim.find((value) => typeof value !== "number");
+
+  if (masterRepresentation === "CARTESIAN") {
+    return cartesianValue ?? parameterValue;
+  }
+  return parameterValue ?? cartesianValue;
+}
+
+function trimValueToParameter(
+  curve: ConicCurve,
+  trim: (IfcCartesianPoint | number)[],
+  fallback: number,
+  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
+): number {
+  const value = preferredTrimValue(trim, masterRepresentation);
+  if (typeof value === "number") {
+    return value;
+  }
+  if (value) {
+    return parameterFromConicPoint(curve, value);
+  }
+  return fallback;
+}
+
+export function resolveConicCurveSegment(
+  curve: ConicCurve,
+  trimmed?: TrimmedCurveParameters,
+): ResolvedCurveSegment {
+  if (!trimmed) {
+    return sampleConic(curve, 0, Math.PI * 2, "curve");
+  }
+
+  const start = normalizeAngle(
+    trimValueToParameter(
+      curve,
+      trimmed.trim1,
+      0,
+      trimmed.masterRepresentation,
+    ),
+  );
+  const end = normalizeAngle(
+    trimValueToParameter(
+      curve,
+      trimmed.trim2,
+      Math.PI * 2,
+      trimmed.masterRepresentation,
+    ),
+  );
+
+  if (trimmed.senseAgreement) {
+    const adjustedEnd = start >= end ? end + Math.PI * 2 : end;
+    return sampleConic(curve, start, adjustedEnd - start, "arc");
+  }
+
+  const adjustedStart = start <= end ? start + Math.PI * 2 : start;
+  return sampleConic(curve, adjustedStart, end - adjustedStart, "arc");
+}

--- a/src/ifc/operations/curve-trimmed.ts
+++ b/src/ifc/operations/curve-trimmed.ts
@@ -1,0 +1,17 @@
+import type { IfcTrimmedCurve } from "../generated/schema.ts";
+import type { ResolvedCurveSegment } from "./curve-types.ts";
+import { resolveConicCurveSegment } from "./curve-conic.ts";
+
+export function resolveTrimmedCurveSegments(
+  curve: IfcTrimmedCurve,
+): ResolvedCurveSegment[] {
+  switch (curve.basisCurve.type) {
+    case "IfcCircle":
+    case "IfcEllipse":
+      return [resolveConicCurveSegment(curve.basisCurve, curve)];
+    default:
+      throw new Error(
+        `IfcTrimmedCurve basis ${curve.basisCurve.type} is not supported yet`,
+      );
+  }
+}

--- a/src/ifc/operations/curve-types.ts
+++ b/src/ifc/operations/curve-types.ts
@@ -1,0 +1,15 @@
+import type { Vec3 } from "../../types.ts";
+
+export type CurveSegmentKind = "line" | "arc" | "curve";
+export type IndexedPolyCurveSegmentKind = "line" | "arc";
+
+export interface ResolvedCurveSegment {
+  kind: CurveSegmentKind;
+  points: Vec3[];
+}
+
+export interface IndexedPolyCurveResolvedSegment
+  extends ResolvedCurveSegment {
+  kind: IndexedPolyCurveSegmentKind;
+  indices: number[];
+}

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -11,34 +11,24 @@ import type {
   IfcSegmentIndexSelect,
   IfcTrimmedCurve,
 } from "../generated/schema.ts";
-import {
-  normalizePlacement2D,
-  normalizePlacement3D,
-  type NormalizedPlacement2D,
-  type NormalizedPlacement3D,
-  type NormalizedVec2,
-  type NormalizedVec3,
-} from "../normalize.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
+import { resolveConicCurveSegment } from "./curve-conic.ts";
+import { resolveTrimmedCurveSegments } from "./curve-trimmed.ts";
+import type {
+  IndexedPolyCurveResolvedSegment,
+  IndexedPolyCurveSegmentKind,
+  ResolvedCurveSegment,
+} from "./curve-types.ts";
+export type {
+  CurveSegmentKind,
+  IndexedPolyCurveResolvedSegment,
+  IndexedPolyCurveSegmentKind,
+  ResolvedCurveSegment,
+} from "./curve-types.ts";
 
 const DEFAULT_ARC_SEGMENTS = 32;
-const DEFAULT_CONIC_SEGMENTS = 64;
 const EPSILON = 1e-9;
-const FULL_CIRCLE_EPSILON = 1e-6;
-
-export type CurveSegmentKind = "line" | "arc" | "curve";
-export type IndexedPolyCurveSegmentKind = "line" | "arc";
-
-export interface ResolvedCurveSegment {
-  kind: CurveSegmentKind;
-  points: Vec3[];
-}
-
-export interface IndexedPolyCurveResolvedSegment extends ResolvedCurveSegment {
-  kind: IndexedPolyCurveSegmentKind;
-  indices: number[];
-}
 
 type RenderableCurve =
   | IfcPolyline
@@ -87,13 +77,6 @@ function normalize(v: Vec3): Vec3 {
   const len = length(v);
   if (len < EPSILON) return { x: 0, y: 0, z: 0 };
   return scale(v, 1 / len);
-}
-
-function normalizeAngle(angle: number): number {
-  const turn = Math.PI * 2;
-  let result = angle % turn;
-  if (result < 0) result += turn;
-  return result;
 }
 
 function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
@@ -170,218 +153,6 @@ function indexedPoints(points: Vec3[], indices: readonly number[]): Vec3[] {
     .filter((point): point is Vec3 => Boolean(point));
 }
 
-function dot2(a: NormalizedVec2, b: NormalizedVec2): number {
-  return a.x * b.x + a.y * b.y;
-}
-
-function dot3Normalized(a: NormalizedVec3, b: NormalizedVec3): number {
-  return a.x * b.x + a.y * b.y + a.z * b.z;
-}
-
-function cross3Normalized(
-  a: NormalizedVec3,
-  b: NormalizedVec3,
-): NormalizedVec3 {
-  return {
-    x: a.y * b.z - a.z * b.y,
-    y: a.z * b.x - a.x * b.z,
-    z: a.x * b.y - a.y * b.x,
-  };
-}
-
-function pointOnPlacement2D(
-  placement: NormalizedPlacement2D,
-  point: NormalizedVec2,
-): Vec3 {
-  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
-  return {
-    x:
-      placement.origin.x +
-      point.x * placement.xAxis.x +
-      point.y * yAxis.x,
-    y:
-      placement.origin.y +
-      point.x * placement.xAxis.y +
-      point.y * yAxis.y,
-    z: 0,
-  };
-}
-
-function localPointOnPlacement3D(
-  placement: NormalizedPlacement3D,
-  point: NormalizedVec2,
-): Vec3 {
-  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
-  return {
-    x:
-      placement.origin.x +
-      point.x * placement.xAxis.x +
-      point.y * yAxis.x,
-    y:
-      placement.origin.y +
-      point.x * placement.xAxis.y +
-      point.y * yAxis.y,
-    z:
-      placement.origin.z +
-      point.x * placement.xAxis.z +
-      point.y * yAxis.z,
-  };
-}
-
-function pointToPlacement2DLocal(
-  placement: NormalizedPlacement2D,
-  point: Vec3,
-): NormalizedVec2 {
-  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
-  const relative = {
-    x: point.x - placement.origin.x,
-    y: point.y - placement.origin.y,
-  };
-  return {
-    x: dot2(relative, placement.xAxis),
-    y: dot2(relative, yAxis),
-  };
-}
-
-function pointToPlacement3DLocal(
-  placement: NormalizedPlacement3D,
-  point: Vec3,
-): NormalizedVec2 {
-  const yAxis = cross3Normalized(placement.zAxis, placement.xAxis);
-  const relative = {
-    x: point.x - placement.origin.x,
-    y: point.y - placement.origin.y,
-    z: point.z - placement.origin.z,
-  };
-  return {
-    x: dot3Normalized(relative, placement.xAxis),
-    y: dot3Normalized(relative, yAxis),
-  };
-}
-
-function pointOnCircleOrEllipse(
-  curve: IfcCircle | IfcEllipse,
-  parameter: number,
-): Vec3 {
-  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
-  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
-  const localPoint = {
-    x: radiusX * Math.cos(parameter),
-    y: radiusY * Math.sin(parameter),
-  };
-
-  return curve.position.type === "IfcAxis2Placement2D"
-    ? pointOnPlacement2D(normalizePlacement2D(curve.position), localPoint)
-    : localPointOnPlacement3D(normalizePlacement3D(curve.position), localPoint);
-}
-
-function parameterFromCircleOrEllipsePoint(
-  curve: IfcCircle | IfcEllipse,
-  point: IfcCartesianPoint,
-): number {
-  const worldPoint = cartesianPointToVec3(point);
-  const localPoint =
-    curve.position.type === "IfcAxis2Placement2D"
-      ? pointToPlacement2DLocal(normalizePlacement2D(curve.position), worldPoint)
-      : pointToPlacement3DLocal(normalizePlacement3D(curve.position), worldPoint);
-  const radiusX = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis1;
-  const radiusY = curve.type === "IfcCircle" ? curve.radius : curve.semiAxis2;
-  return Math.atan2(localPoint.y / radiusY, localPoint.x / radiusX);
-}
-
-function sampleCircleOrEllipse(
-  curve: IfcCircle | IfcEllipse,
-  startParameter: number,
-  sweep: number,
-  kind: CurveSegmentKind,
-): ResolvedCurveSegment {
-  const isClosed = Math.abs(Math.abs(sweep) - Math.PI * 2) <= FULL_CIRCLE_EPSILON;
-  const segmentCount = isClosed
-    ? DEFAULT_CONIC_SEGMENTS
-    : Math.max(
-        2,
-        Math.ceil((Math.abs(sweep) / (Math.PI * 2)) * DEFAULT_CONIC_SEGMENTS),
-      );
-  const points: Vec3[] = [];
-
-  for (let index = 0; index <= segmentCount; index += 1) {
-    const ratio = index / segmentCount;
-    addCurvePoint(
-      points,
-      pointOnCircleOrEllipse(curve, startParameter + sweep * ratio),
-      !isClosed,
-    );
-  }
-
-  return { kind, points };
-}
-
-function preferredTrimValue(
-  trim: (IfcCartesianPoint | number)[],
-  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
-): IfcCartesianPoint | number | undefined {
-  const parameterValue = trim.find((value) => typeof value === "number");
-  const cartesianValue = trim.find((value) => typeof value !== "number");
-
-  if (masterRepresentation === "CARTESIAN") {
-    return cartesianValue ?? parameterValue;
-  }
-  return parameterValue ?? cartesianValue;
-}
-
-function trimValueToParameter(
-  curve: IfcCircle | IfcEllipse,
-  trim: (IfcCartesianPoint | number)[],
-  fallback: number,
-  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
-): number {
-  const value = preferredTrimValue(trim, masterRepresentation);
-  if (typeof value === "number") {
-    return value;
-  }
-  if (value) {
-    return parameterFromCircleOrEllipsePoint(curve, value);
-  }
-  return fallback;
-}
-
-function resolveCircleOrEllipseSegment(
-  curve: IfcCircle | IfcEllipse,
-  trimmed?: Pick<
-    IfcTrimmedCurve,
-    "trim1" | "trim2" | "senseAgreement" | "masterRepresentation"
-  >,
-): ResolvedCurveSegment {
-  if (!trimmed) {
-    return sampleCircleOrEllipse(curve, 0, Math.PI * 2, "curve");
-  }
-
-  const start = normalizeAngle(
-    trimValueToParameter(
-      curve,
-      trimmed.trim1,
-      0,
-      trimmed.masterRepresentation,
-    ),
-  );
-  const end = normalizeAngle(
-    trimValueToParameter(
-      curve,
-      trimmed.trim2,
-      Math.PI * 2,
-      trimmed.masterRepresentation,
-    ),
-  );
-
-  if (trimmed.senseAgreement) {
-    const adjustedEnd = start >= end ? end + Math.PI * 2 : end;
-    return sampleCircleOrEllipse(curve, start, adjustedEnd - start, "arc");
-  }
-
-  const adjustedStart = start <= end ? start + Math.PI * 2 : start;
-  return sampleCircleOrEllipse(curve, adjustedStart, end - adjustedStart, "arc");
-}
-
 function resolveIndexedPolyCurveSegment(
   controlPoints: Vec3[],
   segment: IfcSegmentIndexSelect,
@@ -441,19 +212,10 @@ export function resolveSupportedCurveSegments(
     case "IfcIndexedPolyCurve":
       return resolveIndexedPolyCurveSegments(curve);
     case "IfcCircle":
-      return [resolveCircleOrEllipseSegment(curve)];
     case "IfcEllipse":
-      return [resolveCircleOrEllipseSegment(curve)];
+      return [resolveConicCurveSegment(curve)];
     case "IfcTrimmedCurve":
-      if (curve.basisCurve.type === "IfcCircle") {
-        return [resolveCircleOrEllipseSegment(curve.basisCurve, curve)];
-      }
-      if (curve.basisCurve.type === "IfcEllipse") {
-        return [resolveCircleOrEllipseSegment(curve.basisCurve, curve)];
-      }
-      throw new Error(
-        `IfcTrimmedCurve basis ${curve.basisCurve.type} is not supported yet`,
-      );
+      return resolveTrimmedCurveSegments(curve);
     case "IfcLine":
       throw new Error(
         "IfcLine is infinite and cannot be rendered without a trimming strategy",

--- a/src/ifc/samples/curve.trimmed-circle.ts
+++ b/src/ifc/samples/curve.trimmed-circle.ts
@@ -1,0 +1,9 @@
+import { createTrimmedConicSample } from "./curve.trimmed.shared.ts";
+
+export const curveTrimmedCircleSample = createTrimmedConicSample({
+  id: "curve-trimmed-circle",
+  title: "Trimmed Circle (IfcTrimmedCurve + IfcCircle)",
+  description:
+    "Build a circular arc by trimming an IfcCircle basis curve with parameter-based trim selectors.",
+  basis: "circle",
+});

--- a/src/ifc/samples/curve.trimmed-ellipse.ts
+++ b/src/ifc/samples/curve.trimmed-ellipse.ts
@@ -1,0 +1,9 @@
+import { createTrimmedConicSample } from "./curve.trimmed.shared.ts";
+
+export const curveTrimmedEllipseSample = createTrimmedConicSample({
+  id: "curve-trimmed-ellipse",
+  title: "Trimmed Ellipse (IfcTrimmedCurve + IfcEllipse)",
+  description:
+    "Build an elliptical arc by trimming an IfcEllipse basis curve with parameter-based trim selectors.",
+  basis: "ellipse",
+});

--- a/src/ifc/samples/curve.trimmed.shared.ts
+++ b/src/ifc/samples/curve.trimmed.shared.ts
@@ -5,6 +5,7 @@ import type {
   IfcAxis2Placement3D,
   IfcProfileDef,
   ParamValues,
+  ParameterDef,
   SampleDef,
   SweepViewState,
   Vec3,
@@ -27,40 +28,86 @@ import {
   DEFAULT_CURVE_PLACEMENT,
   pointOnConic,
 } from "./curve.conic.shared.ts";
-const BASIS_CURVE_OPTIONS = ["ELLIPSE", "CIRCLE"] as const;
+
 const SENSE_OPTIONS = ["SAME", "REVERSE"] as const;
 
-function buildBasisCurve(
-  params: ParamValues,
-  placement: IfcAxis2Placement3D,
-): IfcCircle | IfcEllipse {
-  const basis = getSelect(
-    params,
-    "basisCurve",
-    BASIS_CURVE_OPTIONS,
-    BASIS_CURVE_OPTIONS[0],
-  );
-  const radius = getNumber(params, "radius");
-  const semiAxis1 = getNumber(params, "semiAxis1");
-  const semiAxis2 = getNumber(params, "semiAxis2");
+type TrimmedConicBasis = "circle" | "ellipse";
+type TrimmedConicCurve = IfcCircle | IfcEllipse;
 
-  if (basis === "CIRCLE") {
-    return buildIfcCircle(radius, placement);
+interface TrimmedConicSampleConfig {
+  id: string;
+  title: string;
+  description: string;
+  basis: TrimmedConicBasis;
+}
+
+function basisParameters(basis: TrimmedConicBasis): ParameterDef[] {
+  if (basis === "circle") {
+    return [
+      {
+        key: "radius",
+        label: "Radius",
+        type: "number",
+        min: 0.5,
+        max: 8,
+        step: 0.1,
+        defaultValue: 3,
+        group: "Basis Parameters",
+      },
+    ];
   }
 
-  return buildIfcEllipse(semiAxis1, semiAxis2, placement);
+  return [
+    {
+      key: "semiAxis1",
+      label: "Semi-Axis 1",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 4,
+      group: "Basis Parameters",
+    },
+    {
+      key: "semiAxis2",
+      label: "Semi-Axis 2",
+      type: "number",
+      min: 0.5,
+      max: 8,
+      step: 0.1,
+      defaultValue: 2.5,
+      group: "Basis Parameters",
+    },
+  ];
+}
+
+function buildBasisCurve(
+  basis: TrimmedConicBasis,
+  params: ParamValues,
+  placement: IfcAxis2Placement3D,
+): TrimmedConicCurve {
+  if (basis === "circle") {
+    return buildIfcCircle(getNumber(params, "radius"), placement);
+  }
+
+  return buildIfcEllipse(
+    getNumber(params, "semiAxis1"),
+    getNumber(params, "semiAxis2"),
+    placement,
+  );
 }
 
 function buildTrimmedCurve(
+  basis: TrimmedConicBasis,
   params: ParamValues,
   placement: IfcAxis2Placement3D,
 ): {
-  basisCurve: IfcCircle | IfcEllipse;
+  basisCurve: TrimmedConicCurve;
   trimmedCurve: IfcTrimmedCurve;
   remainderCurve: IfcTrimmedCurve;
   trimPoints: Vec3[];
 } {
-  const basisCurve = buildBasisCurve(params, placement);
+  const basisCurve = buildBasisCurve(basis, params, placement);
   const startAngle = (getNumber(params, "startAngleDeg") * Math.PI) / 180;
   const endAngle = (getNumber(params, "endAngleDeg") * Math.PI) / 180;
   const senseAgreement =
@@ -92,10 +139,7 @@ function buildTrimmedCurve(
   return { basisCurve, trimmedCurve, remainderCurve, trimPoints };
 }
 
-function buildTrimPointMarkers(
-  scene: Scene,
-  trimPoints: Vec3[],
-): Mesh[] {
+function buildTrimPointMarkers(scene: Scene, trimPoints: Vec3[]): Mesh[] {
   const startMaterial = getOrCreateSolidMaterial(
     scene,
     "trimmed_curve_start_marker",
@@ -262,160 +306,114 @@ function buildDashedCurve(
   });
 }
 
-export const curveTrimmedSample: SampleDef = {
-  id: "curve-trimmed",
-  title: "Trimmed Curve (IfcTrimmedCurve)",
-  description:
-    "Build circular or elliptical arcs by trimming a reusable basis curve. " +
-    "Inspect how IfcTrimmedCurve wraps IfcCircle and IfcEllipse using parameter-based trims.",
-  parameters: [
-    {
-      key: "basisCurve",
-      label: "Basis Curve",
-      type: "select",
-      options: [
-        { value: "ELLIPSE", label: "Ellipse" },
-        { value: "CIRCLE", label: "Circle" },
-      ],
-      defaultValue: "ELLIPSE",
-      group: "Basis Curve",
-    },
-    {
-      key: "radius",
-      label: "Circle Radius",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 3,
-      group: "Basis Parameters",
-      visibleWhen: {
-        key: "basisCurve",
-        equals: "CIRCLE",
-      },
-    },
-    {
-      key: "semiAxis1",
-      label: "Ellipse Semi-Axis 1",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 4,
-      group: "Basis Parameters",
-      visibleWhen: {
-        key: "basisCurve",
-        equals: "ELLIPSE",
-      },
-    },
-    {
-      key: "semiAxis2",
-      label: "Ellipse Semi-Axis 2",
-      type: "number",
-      min: 0.5,
-      max: 8,
-      step: 0.1,
-      defaultValue: 2.5,
-      group: "Basis Parameters",
-      visibleWhen: {
-        key: "basisCurve",
-        equals: "ELLIPSE",
-      },
-    },
-    {
-      key: "sense",
-      label: "Sense",
-      type: "select",
-      options: [
-        { value: "SAME", label: "Same" },
-        { value: "REVERSE", label: "Reverse" },
-      ],
-      defaultValue: "SAME",
-      group: "Trim",
-    },
-    {
-      key: "startAngleDeg",
-      label: "Start Angle",
-      type: "number",
-      min: 0,
-      max: 360,
-      step: 1,
-      defaultValue: 25,
-      group: "Trim",
-    },
-    {
-      key: "endAngleDeg",
-      label: "End Angle",
-      type: "number",
-      min: 0,
-      max: 360,
-      step: 1,
-      defaultValue: 305,
-      group: "Trim",
-    },
-  ],
-  steps: [
-    {
-      id: "basis-curve",
-      label: "Step 1: Basis Curve",
-      description:
-        "IfcTrimmedCurve starts from a full IfcCircle or IfcEllipse basisCurve. " +
-        "This step shows the reusable base geometry before any trim is applied.",
-    },
-    {
-      id: "trimmed-curve",
-      label: "Step 2: Trim",
-      description:
-        "The trim selectors choose the start and end positions on the basis curve, and " +
-        "senseAgreement controls whether the visible segment follows the basis direction or the reverse direction.",
-    },
-  ],
-  placementEditorConfig: {
-    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
-  },
-  buildGeometry: (
-    scene: Scene,
-    params: ParamValues,
-    stepIndex: number,
-    _profile?: IfcProfileDef,
-    _path?: Vec3[],
-    _extrusion?: ExtrusionParams,
-    placement?: IfcAxis2Placement3D,
-    _sweepView?: SweepViewState,
-  ): Mesh[] => {
-    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
-    const { basisCurve, trimmedCurve, remainderCurve, trimPoints } = buildTrimmedCurve(
-      params,
-      activePlacement,
-    );
-    const meshes: Mesh[] =
-      stepIndex === 0
-        ? [
-            ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
-              curveColor: new Color3(0.55, 0.6, 0.7),
-            }),
-          ]
-        : [];
+export function createTrimmedConicSample(
+  config: TrimmedConicSampleConfig,
+): SampleDef {
+  const basisLabel = config.basis === "circle" ? "IfcCircle" : "IfcEllipse";
 
-    if (stepIndex >= 1) {
-      meshes.push(
-        ...buildTrimPointMarkers(scene, trimPoints),
-        ...buildDashedCurve(
-          scene,
-          remainderCurve,
-          "trimmed_curve_remainder",
-          new Color3(0.42, 0.46, 0.54),
-        ),
-        ...buildSupportedCurve(scene, trimmedCurve, "trimmed_curve_result", {
-          curveColor: new Color3(1, 0.75, 0.2),
-          arcColor: new Color3(1, 0.75, 0.2),
-        }),
-        ...buildResultEndMarkers(scene, trimmedCurve),
-      );
-    }
+  return {
+    id: config.id,
+    title: config.title,
+    description: config.description,
+    parameters: [
+      ...basisParameters(config.basis),
+      {
+        key: "sense",
+        label: "Sense",
+        type: "select",
+        options: [
+          { value: "SAME", label: "Same" },
+          { value: "REVERSE", label: "Reverse" },
+        ],
+        defaultValue: "SAME",
+        group: "Trim",
+      },
+      {
+        key: "startAngleDeg",
+        label: "Start Angle",
+        type: "number",
+        min: 0,
+        max: 360,
+        step: 1,
+        defaultValue: 25,
+        group: "Trim",
+      },
+      {
+        key: "endAngleDeg",
+        label: "End Angle",
+        type: "number",
+        min: 0,
+        max: 360,
+        step: 1,
+        defaultValue: 305,
+        group: "Trim",
+      },
+    ],
+    steps: [
+      {
+        id: "basis-curve",
+        label: "Step 1: Basis Curve",
+        description:
+          `IfcTrimmedCurve starts from a full ${basisLabel} basisCurve. ` +
+          "This step shows the reusable base geometry before any trim is applied.",
+      },
+      {
+        id: "trimmed-curve",
+        label: "Step 2: Trim",
+        description:
+          "The trim selectors choose the start and end positions on the basis curve, and " +
+          "senseAgreement controls whether the visible segment follows the basis direction or the reverse direction.",
+      },
+    ],
+    placementEditorConfig: {
+      defaultPlacement: DEFAULT_CURVE_PLACEMENT,
+    },
+    buildGeometry: (
+      scene: Scene,
+      params: ParamValues,
+      stepIndex: number,
+      _profile?: IfcProfileDef,
+      _path?: Vec3[],
+      _extrusion?: ExtrusionParams,
+      placement?: IfcAxis2Placement3D,
+      _sweepView?: SweepViewState,
+    ): Mesh[] => {
+      const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
+      const { basisCurve, trimmedCurve, remainderCurve, trimPoints } =
+        buildTrimmedCurve(config.basis, params, activePlacement);
+      const meshes: Mesh[] =
+        stepIndex === 0
+          ? [
+              ...buildSupportedCurve(scene, basisCurve, "trimmed_curve_basis", {
+                curveColor: new Color3(0.55, 0.6, 0.7),
+              }),
+            ]
+          : [];
 
-    return meshes;
-  },
-  getIFCRepresentation: (params: ParamValues) =>
-    buildTrimmedCurve(params, DEFAULT_CURVE_PLACEMENT).trimmedCurve,
-};
+      if (stepIndex >= 1) {
+        meshes.push(
+          ...buildTrimPointMarkers(scene, trimPoints),
+          ...buildDashedCurve(
+            scene,
+            remainderCurve,
+            "trimmed_curve_remainder",
+            new Color3(0.42, 0.46, 0.54),
+          ),
+          ...buildSupportedCurve(scene, trimmedCurve, "trimmed_curve_result", {
+            curveColor: new Color3(1, 0.75, 0.2),
+            arcColor: new Color3(1, 0.75, 0.2),
+          }),
+          ...buildResultEndMarkers(scene, trimmedCurve),
+        );
+      }
+
+      return meshes;
+    },
+    getIFCRepresentation: (params: ParamValues) =>
+      buildTrimmedCurve(
+        config.basis,
+        params,
+        DEFAULT_CURVE_PLACEMENT,
+      ).trimmedCurve,
+  };
+}


### PR DESCRIPTION
## Summary
- Split conic curve sampling and trimming logic out of the generic curve operation module.
- Added a thin IfcTrimmedCurve dispatcher so future basis curves can be added without growing the main curve switch.
- Split the trimmed curve example into basis-specific circle and ellipse samples/routes.

## Validation
- `bun run build`