### PR TITLE
[codex] Add trimmed line curve sample

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -19,6 +19,7 @@ import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
+import { curveLineSample } from "../ifc/samples/curve.line.ts";
 import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
 import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
 import { curveTrimmedCircleSample } from "../ifc/samples/curve.trimmed-circle.ts";
@@ -28,6 +29,7 @@ import type { SampleDef } from "../types.ts";
 const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
+  "curve-line": curveLineSample,
   "curve-circle": curveCircleSample,
   "curve-ellipse": curveEllipseSample,
   "curve-trimmed-circle": curveTrimmedCircleSample,

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -24,6 +24,7 @@ import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
 import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
 import { curveTrimmedCircleSample } from "../ifc/samples/curve.trimmed-circle.ts";
 import { curveTrimmedEllipseSample } from "../ifc/samples/curve.trimmed-ellipse.ts";
+import { curveTrimmedLineSample } from "../ifc/samples/curve.trimmed-line.ts";
 import type { SampleDef } from "../types.ts";
 
 const samples: Record<string, SampleDef> = {
@@ -34,6 +35,7 @@ const samples: Record<string, SampleDef> = {
   "curve-ellipse": curveEllipseSample,
   "curve-trimmed-circle": curveTrimmedCircleSample,
   "curve-trimmed-ellipse": curveTrimmedEllipseSample,
+  "curve-trimmed-line": curveTrimmedLineSample,
   "extrusion-rectangle": extrusionRectangleSample,
   "extrusion-rounded-rectangle": extrusionRoundedRectangleSample,
   "boolean-difference": booleanDifferenceSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -146,6 +146,20 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
+    hash: "#/examples/curve-line",
+    title: "Line",
+    description:
+      "Define an infinite IfcLine from Pnt and Dir, displayed as a finite magnitude segment.",
+    sampleId: "curve-line",
+    domain: "Curves",
+    difficulty: "beginner",
+    exampleKind: "primary",
+    status: "available",
+    entity: "IfcLine",
+    dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
+  },
+  {
     hash: "#/examples/curve-circle",
     title: "Circle",
     description:
@@ -503,6 +517,15 @@ export const implementationMap: ImplementationMapItem[] = [
     status: "available",
     description: "Indexed curve representation for compact polyline and arc paths.",
     routeHash: "#/examples/curve-indexed-polycurve",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcLine",
+    domain: "Curves",
+    status: "available",
+    description:
+      "Infinite line represented from Pnt and Dir, with Magnitude used as the standalone display segment.",
+    routeHash: "#/examples/curve-line",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -216,6 +216,20 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
+    hash: "#/examples/curve-trimmed-line",
+    title: "Trimmed Line",
+    description:
+      "Trim an IfcLine basis curve with parameter selectors that may extend outside the displayed magnitude segment.",
+    sampleId: "curve-trimmed-line",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "variant",
+    status: "available",
+    entity: "IfcTrimmedCurve",
+    dependsOn: ["IfcCurve", "IfcLine"],
+    operationGroup: "curve-primitives",
+  },
+  {
     hash: "#/examples/profiles",
     title: "Profiles",
     description:

--- a/src/ifc/operations/curve-conic.ts
+++ b/src/ifc/operations/curve-conic.ts
@@ -14,6 +14,7 @@ import {
 } from "../normalize.ts";
 import type { Vec3 } from "../../types.ts";
 import type { CurveSegmentKind, ResolvedCurveSegment } from "./curve-types.ts";
+import { cartesianPointToVec3 } from "./curve-line.ts";
 
 const DEFAULT_CONIC_SEGMENTS = 64;
 const EPSILON = 1e-9;
@@ -37,14 +38,6 @@ function normalizeAngle(angle: number): number {
   let result = angle % turn;
   if (result < 0) result += turn;
   return result;
-}
-
-function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
-  return {
-    x: point.coordinates[0] ?? 0,
-    y: point.coordinates[1] ?? 0,
-    z: point.coordinates[2] ?? 0,
-  };
 }
 
 function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {

--- a/src/ifc/operations/curve-line.ts
+++ b/src/ifc/operations/curve-line.ts
@@ -1,0 +1,75 @@
+import type {
+  IfcCartesianPoint,
+  IfcLine,
+} from "../generated/schema.ts";
+import type { Vec3 } from "../../types.ts";
+import type { ResolvedCurveSegment } from "./curve-types.ts";
+
+const EPSILON = 1e-9;
+
+interface LineParameterRange {
+  startParameter?: number;
+  endParameter?: number;
+  senseAgreement?: boolean;
+}
+
+function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
+}
+
+function scale(v: Vec3, factor: number): Vec3 {
+  return { x: v.x * factor, y: v.y * factor, z: v.z * factor };
+}
+
+function add(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function length(v: Vec3): number {
+  return Math.hypot(v.x, v.y, v.z);
+}
+
+export function getLineStartPoint(line: IfcLine): Vec3 {
+  return cartesianPointToVec3(line.pnt);
+}
+
+export function getLineDirection(line: IfcLine): Vec3 {
+  const ratios = line.dir.orientation.directionRatios;
+  const direction = {
+    x: ratios[0] ?? 0,
+    y: ratios[1] ?? 0,
+    z: ratios[2] ?? 0,
+  };
+  const directionLength = length(direction);
+
+  if (directionLength < EPSILON) {
+    return { x: 0, y: 0, z: 0 };
+  }
+
+  return scale(direction, line.dir.magnitude / directionLength);
+}
+
+export function pointOnLine(line: IfcLine, parameter: number): Vec3 {
+  return add(getLineStartPoint(line), scale(getLineDirection(line), parameter));
+}
+
+export function resolveLineCurveSegment(
+  line: IfcLine,
+  range: LineParameterRange = {},
+): ResolvedCurveSegment {
+  const startParameter = range.startParameter ?? 0;
+  const endParameter = range.endParameter ?? 1;
+  const points = [
+    pointOnLine(line, startParameter),
+    pointOnLine(line, endParameter),
+  ];
+
+  return {
+    kind: "line",
+    points: range.senseAgreement === false ? points.reverse() : points,
+  };
+}

--- a/src/ifc/operations/curve-line.ts
+++ b/src/ifc/operations/curve-line.ts
@@ -13,7 +13,7 @@ interface LineParameterRange {
   senseAgreement?: boolean;
 }
 
-function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
+export function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
   return {
     x: point.coordinates[0] ?? 0,
     y: point.coordinates[1] ?? 0,

--- a/src/ifc/operations/curve-trimmed.ts
+++ b/src/ifc/operations/curve-trimmed.ts
@@ -1,6 +1,72 @@
-import type { IfcTrimmedCurve } from "../generated/schema.ts";
+import type { IfcCartesianPoint, IfcTrimmedCurve } from "../generated/schema.ts";
 import type { ResolvedCurveSegment } from "./curve-types.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
+import { resolveLineCurveSegment } from "./curve-line.ts";
+
+function isCartesianPoint(value: unknown): value is IfcCartesianPoint {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "type" in value &&
+      value.type === "IfcCartesianPoint",
+  );
+}
+
+function cartesianPointToVec3(point: IfcCartesianPoint) {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
+}
+
+function getTrimParameter(trim: IfcTrimmedCurve["trim1"]): number | undefined {
+  return trim.find((value): value is number => typeof value === "number");
+}
+
+function getTrimPoint(
+  trim: IfcTrimmedCurve["trim1"],
+): IfcCartesianPoint | undefined {
+  return trim.find(isCartesianPoint);
+}
+
+function resolveLineTrimmedCurveSegment(
+  curve: IfcTrimmedCurve,
+): ResolvedCurveSegment {
+  if (curve.basisCurve.type !== "IfcLine") {
+    throw new Error(`Expected IfcLine basis, got ${curve.basisCurve.type}`);
+  }
+
+  const startParameter = getTrimParameter(curve.trim1);
+  const endParameter = getTrimParameter(curve.trim2);
+
+  if (startParameter !== undefined && endParameter !== undefined) {
+    return resolveLineCurveSegment(curve.basisCurve, {
+      startParameter,
+      endParameter,
+      senseAgreement: curve.senseAgreement,
+    });
+  }
+
+  const startPoint = getTrimPoint(curve.trim1);
+  const endPoint = getTrimPoint(curve.trim2);
+
+  if (startPoint && endPoint) {
+    const points = [
+      cartesianPointToVec3(startPoint),
+      cartesianPointToVec3(endPoint),
+    ];
+
+    return {
+      kind: "line",
+      points: curve.senseAgreement ? points : points.reverse(),
+    };
+  }
+
+  throw new Error(
+    "IfcTrimmedCurve + IfcLine requires numeric parameter trims or cartesian point trims",
+  );
+}
 
 export function resolveTrimmedCurveSegments(
   curve: IfcTrimmedCurve,
@@ -9,6 +75,8 @@ export function resolveTrimmedCurveSegments(
     case "IfcCircle":
     case "IfcEllipse":
       return [resolveConicCurveSegment(curve.basisCurve, curve)];
+    case "IfcLine":
+      return [resolveLineTrimmedCurveSegment(curve)];
     default:
       throw new Error(
         `IfcTrimmedCurve basis ${curve.basisCurve.type} is not supported yet`,

--- a/src/ifc/operations/curve-trimmed.ts
+++ b/src/ifc/operations/curve-trimmed.ts
@@ -1,7 +1,7 @@
 import type { IfcCartesianPoint, IfcTrimmedCurve } from "../generated/schema.ts";
 import type { ResolvedCurveSegment } from "./curve-types.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
-import { resolveLineCurveSegment } from "./curve-line.ts";
+import { cartesianPointToVec3, resolveLineCurveSegment } from "./curve-line.ts";
 
 function isCartesianPoint(value: unknown): value is IfcCartesianPoint {
   return Boolean(
@@ -10,14 +10,6 @@ function isCartesianPoint(value: unknown): value is IfcCartesianPoint {
       "type" in value &&
       value.type === "IfcCartesianPoint",
   );
-}
-
-function cartesianPointToVec3(point: IfcCartesianPoint) {
-  return {
-    x: point.coordinates[0] ?? 0,
-    y: point.coordinates[1] ?? 0,
-    z: point.coordinates[2] ?? 0,
-  };
 }
 
 function getTrimParameter(trim: IfcTrimmedCurve["trim1"]): number | undefined {
@@ -30,6 +22,18 @@ function getTrimPoint(
   return trim.find(isCartesianPoint);
 }
 
+function getPreferredTrimValue(
+  trim: IfcTrimmedCurve["trim1"],
+  masterRepresentation: IfcTrimmedCurve["masterRepresentation"],
+): number | IfcCartesianPoint | undefined {
+  const parameterValue = getTrimParameter(trim);
+  const cartesianValue = getTrimPoint(trim);
+  if (masterRepresentation === "CARTESIAN") {
+    return cartesianValue ?? parameterValue;
+  }
+  return parameterValue ?? cartesianValue;
+}
+
 function resolveLineTrimmedCurveSegment(
   curve: IfcTrimmedCurve,
 ): ResolvedCurveSegment {
@@ -37,29 +41,26 @@ function resolveLineTrimmedCurveSegment(
     throw new Error(`Expected IfcLine basis, got ${curve.basisCurve.type}`);
   }
 
-  const startParameter = getTrimParameter(curve.trim1);
-  const endParameter = getTrimParameter(curve.trim2);
+  const { trim1, trim2, senseAgreement, masterRepresentation } = curve;
+  const startValue = getPreferredTrimValue(trim1, masterRepresentation);
+  const endValue = getPreferredTrimValue(trim2, masterRepresentation);
 
-  if (startParameter !== undefined && endParameter !== undefined) {
+  if (typeof startValue === "number" && typeof endValue === "number") {
     return resolveLineCurveSegment(curve.basisCurve, {
-      startParameter,
-      endParameter,
-      senseAgreement: curve.senseAgreement,
+      startParameter: startValue,
+      endParameter: endValue,
+      senseAgreement,
     });
   }
 
-  const startPoint = getTrimPoint(curve.trim1);
-  const endPoint = getTrimPoint(curve.trim2);
-
-  if (startPoint && endPoint) {
+  if (isCartesianPoint(startValue) && isCartesianPoint(endValue)) {
     const points = [
-      cartesianPointToVec3(startPoint),
-      cartesianPointToVec3(endPoint),
+      cartesianPointToVec3(startValue),
+      cartesianPointToVec3(endValue),
     ];
-
     return {
       kind: "line",
-      points: curve.senseAgreement ? points : points.reverse(),
+      points: senseAgreement ? points : points.reverse(),
     };
   }
 

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -14,6 +14,7 @@ import type {
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
+import { resolveLineCurveSegment } from "./curve-line.ts";
 import { resolveTrimmedCurveSegments } from "./curve-trimmed.ts";
 import type {
   IndexedPolyCurveResolvedSegment,
@@ -217,9 +218,7 @@ export function resolveSupportedCurveSegments(
     case "IfcTrimmedCurve":
       return resolveTrimmedCurveSegments(curve);
     case "IfcLine":
-      throw new Error(
-        "IfcLine is infinite and cannot be rendered without a trimming strategy",
-      );
+      return [resolveLineCurveSegment(curve)];
     default: {
       const _exhaustive: never = curve;
       throw new Error(`Curve type is not supported yet: ${String(_exhaustive)}`);

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -1,7 +1,6 @@
 import { Color3, Mesh, MeshBuilder } from "@babylonjs/core";
 import type { Scene, StandardMaterial } from "@babylonjs/core";
 import type {
-  IfcCartesianPoint,
   IfcCartesianPointList,
   IfcCircle,
   IfcEllipse,
@@ -14,7 +13,7 @@ import type {
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
-import { resolveLineCurveSegment } from "./curve-line.ts";
+import { cartesianPointToVec3, resolveLineCurveSegment } from "./curve-line.ts";
 import { resolveTrimmedCurveSegments } from "./curve-trimmed.ts";
 import type {
   IndexedPolyCurveResolvedSegment,
@@ -78,14 +77,6 @@ function normalize(v: Vec3): Vec3 {
   const len = length(v);
   if (len < EPSILON) return { x: 0, y: 0, z: 0 };
   return scale(v, 1 / len);
-}
-
-function cartesianPointToVec3(point: IfcCartesianPoint): Vec3 {
-  return {
-    x: point.coordinates[0] ?? 0,
-    y: point.coordinates[1] ?? 0,
-    z: point.coordinates[2] ?? 0,
-  };
 }
 
 function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {

--- a/src/ifc/samples/curve.line.ts
+++ b/src/ifc/samples/curve.line.ts
@@ -143,23 +143,17 @@ export const curveLineSample: SampleDef = {
   ],
   steps: [
     {
-      id: "attributes",
-      label: "Step 1: Pnt + Dir",
+      id: "line",
+      label: "IfcLine",
       description:
         "IfcLine stores one point on the infinite line and an IfcVector. " +
-        "The vector is split into DirectionRatios and Magnitude.",
-    },
-    {
-      id: "display-segment",
-      label: "Step 2: Magnitude Segment",
-      description:
         "For display, the infinite line is represented as Pnt plus the normalized Dir.Orientation scaled by Dir.Magnitude.",
     },
   ],
   buildGeometry: (
     scene: Scene,
     params: ParamValues,
-    stepIndex: number,
+    _stepIndex: number,
     _profile?: IfcProfileDef,
     _path?: Vec3[],
     _extrusion?: ExtrusionParams,
@@ -169,26 +163,19 @@ export const curveLineSample: SampleDef = {
     const line = buildIfcLine(params);
     const start = getLineStartPoint(line);
     const end = pointOnLine(line, 1);
-    const meshes: Mesh[] = [
+    return [
       buildPointMarker(scene, start, "curve_line_pnt", new Color3(0.25, 0.55, 1)),
+      ...buildSupportedCurve(scene, line, "curve_line_result", {
+        lineColor: new Color3(1, 0.75, 0.2),
+      }),
+      buildPointMarker(
+        scene,
+        end,
+        "curve_line_magnitude_end",
+        new Color3(1, 0.55, 0.15),
+        0.18,
+      ),
     ];
-
-    if (stepIndex >= 1) {
-      meshes.push(
-        ...buildSupportedCurve(scene, line, "curve_line_result", {
-          lineColor: new Color3(1, 0.75, 0.2),
-        }),
-        buildPointMarker(
-          scene,
-          end,
-          "curve_line_magnitude_end",
-          new Color3(1, 0.55, 0.15),
-          0.18,
-        ),
-      );
-    }
-
-    return meshes;
   },
   getIFCRepresentation: (params: ParamValues) => buildIfcLine(params),
 };

--- a/src/ifc/samples/curve.line.ts
+++ b/src/ifc/samples/curve.line.ts
@@ -1,0 +1,194 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import type { IfcDirection, IfcLine } from "../generated/schema.ts";
+import { buildSupportedCurve } from "../operations/curve.ts";
+import { getLineStartPoint, pointOnLine } from "../operations/curve-line.ts";
+
+function toIfcDirection(direction: Vec3): IfcDirection {
+  return {
+    type: "IfcDirection",
+    directionRatios: [direction.x, direction.y, direction.z],
+  };
+}
+
+function buildIfcLine(params: ParamValues): IfcLine {
+  return {
+    type: "IfcLine",
+    pnt: {
+      type: "IfcCartesianPoint",
+      coordinates: [
+        getNumber(params, "pntX"),
+        getNumber(params, "pntY"),
+        getNumber(params, "pntZ"),
+      ],
+    },
+    dir: {
+      type: "IfcVector",
+      orientation: toIfcDirection({
+        x: getNumber(params, "dirX"),
+        y: getNumber(params, "dirY"),
+        z: getNumber(params, "dirZ"),
+      }),
+      magnitude: getNumber(params, "magnitude"),
+    },
+  };
+}
+
+function buildPointMarker(
+  scene: Scene,
+  point: Vec3,
+  name: string,
+  color: Color3,
+  diameter = 0.22,
+): Mesh {
+  const marker = MeshBuilder.CreateSphere(
+    name,
+    { diameter, segments: 16 },
+    scene,
+  );
+  marker.position = ifcToBabylonVector(point);
+  marker.material = getOrCreateSolidMaterial(scene, `${name}_material`, color);
+  return marker;
+}
+
+export const curveLineSample: SampleDef = {
+  id: "curve-line",
+  title: "Line (IfcLine)",
+  description:
+    "Inspect an IfcLine from its explicit Pnt and Dir attributes. Because the IFC line is infinite, " +
+    "this sample renders the Dir magnitude as a finite segment for display.",
+  parameters: [
+    {
+      key: "pntX",
+      label: "Pnt X",
+      type: "number",
+      min: -6,
+      max: 6,
+      step: 0.1,
+      defaultValue: -2,
+      group: "Pnt",
+    },
+    {
+      key: "pntY",
+      label: "Pnt Y",
+      type: "number",
+      min: -6,
+      max: 6,
+      step: 0.1,
+      defaultValue: -1,
+      group: "Pnt",
+    },
+    {
+      key: "pntZ",
+      label: "Pnt Z",
+      type: "number",
+      min: -2,
+      max: 6,
+      step: 0.1,
+      defaultValue: 0.5,
+      group: "Pnt",
+    },
+    {
+      key: "dirX",
+      label: "Dir Orientation X",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 1,
+      group: "Dir",
+    },
+    {
+      key: "dirY",
+      label: "Dir Orientation Y",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 0.35,
+      group: "Dir",
+    },
+    {
+      key: "dirZ",
+      label: "Dir Orientation Z",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 0.25,
+      group: "Dir",
+    },
+    {
+      key: "magnitude",
+      label: "Dir Magnitude",
+      type: "number",
+      min: 0.1,
+      max: 10,
+      step: 0.1,
+      defaultValue: 5,
+      group: "Dir",
+    },
+  ],
+  steps: [
+    {
+      id: "attributes",
+      label: "Step 1: Pnt + Dir",
+      description:
+        "IfcLine stores one point on the infinite line and an IfcVector. " +
+        "The vector is split into DirectionRatios and Magnitude.",
+    },
+    {
+      id: "display-segment",
+      label: "Step 2: Magnitude Segment",
+      description:
+        "For display, the infinite line is represented as Pnt plus the normalized Dir.Orientation scaled by Dir.Magnitude.",
+    },
+  ],
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const line = buildIfcLine(params);
+    const start = getLineStartPoint(line);
+    const end = pointOnLine(line, 1);
+    const meshes: Mesh[] = [
+      buildPointMarker(scene, start, "curve_line_pnt", new Color3(0.25, 0.55, 1)),
+    ];
+
+    if (stepIndex >= 1) {
+      meshes.push(
+        ...buildSupportedCurve(scene, line, "curve_line_result", {
+          lineColor: new Color3(1, 0.75, 0.2),
+        }),
+        buildPointMarker(
+          scene,
+          end,
+          "curve_line_magnitude_end",
+          new Color3(1, 0.55, 0.15),
+          0.18,
+        ),
+      );
+    }
+
+    return meshes;
+  },
+  getIFCRepresentation: (params: ParamValues) => buildIfcLine(params),
+};

--- a/src/ifc/samples/curve.trimmed-line.ts
+++ b/src/ifc/samples/curve.trimmed-line.ts
@@ -1,0 +1,344 @@
+import { Color3, MeshBuilder, Vector3 } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber, getSelect } from "../../types.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import type {
+  IfcDirection,
+  IfcLine,
+  IfcTrimmedCurve,
+} from "../generated/schema.ts";
+import {
+  buildSupportedCurve,
+  resolveSupportedCurveSegments,
+} from "../operations/curve.ts";
+import {
+  getLineStartPoint,
+  pointOnLine,
+  resolveLineCurveSegment,
+} from "../operations/curve-line.ts";
+
+const SENSE_OPTIONS = ["SAME", "REVERSE"] as const;
+
+function toIfcDirection(direction: Vec3): IfcDirection {
+  return {
+    type: "IfcDirection",
+    directionRatios: [direction.x, direction.y, direction.z],
+  };
+}
+
+function buildIfcLine(params: ParamValues): IfcLine {
+  return {
+    type: "IfcLine",
+    pnt: {
+      type: "IfcCartesianPoint",
+      coordinates: [
+        getNumber(params, "pntX"),
+        getNumber(params, "pntY"),
+        getNumber(params, "pntZ"),
+      ],
+    },
+    dir: {
+      type: "IfcVector",
+      orientation: toIfcDirection({
+        x: getNumber(params, "dirX"),
+        y: getNumber(params, "dirY"),
+        z: getNumber(params, "dirZ"),
+      }),
+      magnitude: getNumber(params, "magnitude"),
+    },
+  };
+}
+
+function buildTrimmedLine(params: ParamValues): {
+  basisCurve: IfcLine;
+  trimmedCurve: IfcTrimmedCurve;
+} {
+  const basisCurve = buildIfcLine(params);
+  const senseAgreement =
+    getSelect(params, "sense", SENSE_OPTIONS, SENSE_OPTIONS[0]) === "SAME";
+
+  return {
+    basisCurve,
+    trimmedCurve: {
+      type: "IfcTrimmedCurve",
+      basisCurve,
+      trim1: [getNumber(params, "startParameter")],
+      trim2: [getNumber(params, "endParameter")],
+      senseAgreement,
+      masterRepresentation: "PARAMETER",
+    },
+  };
+}
+
+function buildPointMarker(
+  scene: Scene,
+  point: Vec3,
+  name: string,
+  color: Color3,
+  diameter = 0.2,
+): Mesh {
+  const marker = MeshBuilder.CreateSphere(
+    name,
+    { diameter, segments: 16 },
+    scene,
+  );
+  marker.position = ifcToBabylonVector(point);
+  marker.material = getOrCreateSolidMaterial(scene, `${name}_material`, color);
+  return marker;
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  return Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z);
+}
+
+function interpolatePoint(a: Vec3, b: Vec3, ratio: number): Vec3 {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+    z: a.z + (b.z - a.z) * ratio,
+  };
+}
+
+function buildDashedLineSegment(
+  scene: Scene,
+  points: Vec3[],
+  name: string,
+  color: Color3,
+): Mesh[] {
+  if (points.length < 2) return [];
+
+  const [start, end] = points;
+  const totalLength = distance(start, end);
+  if (totalLength <= 1e-9) return [];
+
+  const dashLength = 0.22;
+  const gapLength = 0.12;
+  const lines: Vector3[][] = [];
+
+  for (let cursor = 0; cursor < totalLength; cursor += dashLength + gapLength) {
+    const dashStart = cursor / totalLength;
+    const dashEnd = Math.min(cursor + dashLength, totalLength) / totalLength;
+    lines.push([
+      ifcToBabylonVector(interpolatePoint(start, end, dashStart)),
+      ifcToBabylonVector(interpolatePoint(start, end, dashEnd)),
+    ]);
+  }
+
+  const dashed = MeshBuilder.CreateLineSystem(name, { lines }, scene);
+  dashed.color = color;
+  return [dashed];
+}
+
+function buildTrimEndpointMarkers(
+  scene: Scene,
+  trimmedCurve: IfcTrimmedCurve,
+): Mesh[] {
+  const points = resolveSupportedCurveSegments(trimmedCurve)[0]?.points ?? [];
+  if (points.length < 2) return [];
+
+  return [
+    buildPointMarker(
+      scene,
+      points[0],
+      "trimmed_line_start",
+      new Color3(0.25, 0.55, 1),
+      0.18,
+    ),
+    buildPointMarker(
+      scene,
+      points[points.length - 1],
+      "trimmed_line_end",
+      new Color3(1, 0.55, 0.15),
+      0.18,
+    ),
+  ];
+}
+
+export const curveTrimmedLineSample: SampleDef = {
+  id: "curve-trimmed-line",
+  title: "Trimmed Line (IfcTrimmedCurve + IfcLine)",
+  description:
+    "Trim an IfcLine basis curve with parameter selectors. The visible IfcLine guide uses the same finite " +
+    "Magnitude segment as the standalone sample, while trims may extend outside that display range.",
+  parameters: [
+    {
+      key: "pntX",
+      label: "Pnt X",
+      type: "number",
+      min: -6,
+      max: 6,
+      step: 0.1,
+      defaultValue: -2,
+      group: "Pnt",
+    },
+    {
+      key: "pntY",
+      label: "Pnt Y",
+      type: "number",
+      min: -6,
+      max: 6,
+      step: 0.1,
+      defaultValue: -1,
+      group: "Pnt",
+    },
+    {
+      key: "pntZ",
+      label: "Pnt Z",
+      type: "number",
+      min: -2,
+      max: 6,
+      step: 0.1,
+      defaultValue: 0.5,
+      group: "Pnt",
+    },
+    {
+      key: "dirX",
+      label: "Dir Orientation X",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 1,
+      group: "Dir",
+    },
+    {
+      key: "dirY",
+      label: "Dir Orientation Y",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 0.35,
+      group: "Dir",
+    },
+    {
+      key: "dirZ",
+      label: "Dir Orientation Z",
+      type: "number",
+      min: -1,
+      max: 1,
+      step: 0.05,
+      defaultValue: 0.25,
+      group: "Dir",
+    },
+    {
+      key: "magnitude",
+      label: "Dir Magnitude",
+      type: "number",
+      min: 0.1,
+      max: 10,
+      step: 0.1,
+      defaultValue: 5,
+      group: "Dir",
+    },
+    {
+      key: "sense",
+      label: "Sense",
+      type: "select",
+      options: [
+        { value: "SAME", label: "Same" },
+        { value: "REVERSE", label: "Reverse" },
+      ],
+      defaultValue: "SAME",
+      group: "Trim",
+    },
+    {
+      key: "startParameter",
+      label: "Start Parameter",
+      type: "number",
+      min: -2,
+      max: 3,
+      step: 0.05,
+      defaultValue: -0.25,
+      group: "Trim",
+    },
+    {
+      key: "endParameter",
+      label: "End Parameter",
+      type: "number",
+      min: -2,
+      max: 3,
+      step: 0.05,
+      defaultValue: 1.25,
+      group: "Trim",
+    },
+  ],
+  steps: [
+    {
+      id: "basis-line",
+      label: "Step 1: IfcLine",
+      description:
+        "The basis IfcLine is infinite, but the sample displays Pnt plus Dir.Magnitude as a finite guide segment.",
+    },
+    {
+      id: "trimmed-line",
+      label: "Step 2: Trim",
+      description:
+        "IfcTrimmedCurve applies parameter trims on the infinite basis line. The original guide is dotted and the trimmed result is solid.",
+    },
+  ],
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const { basisCurve, trimmedCurve } = buildTrimmedLine(params);
+    const basisStart = getLineStartPoint(basisCurve);
+    const basisEnd = pointOnLine(basisCurve, 1);
+    const basisMeshes = [
+      buildPointMarker(
+        scene,
+        basisStart,
+        "trimmed_line_pnt",
+        new Color3(0.25, 0.55, 1),
+      ),
+      buildPointMarker(
+        scene,
+        basisEnd,
+        "trimmed_line_magnitude_end",
+        new Color3(1, 0.55, 0.15),
+        0.18,
+      ),
+    ];
+
+    if (stepIndex === 0) {
+      return [
+        ...basisMeshes,
+        ...buildSupportedCurve(scene, basisCurve, "trimmed_line_basis", {
+          lineColor: new Color3(1, 0.75, 0.2),
+        }),
+      ];
+    }
+
+    return [
+      ...basisMeshes,
+      ...buildDashedLineSegment(
+        scene,
+        resolveLineCurveSegment(basisCurve).points,
+        "trimmed_line_basis_dashed",
+        new Color3(0.42, 0.46, 0.54),
+      ),
+      ...buildSupportedCurve(scene, trimmedCurve, "trimmed_line_result", {
+        lineColor: new Color3(1, 0.75, 0.2),
+      }),
+      ...buildTrimEndpointMarkers(scene, trimmedCurve),
+    ];
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildTrimmedLine(params).trimmedCurve,
+};


### PR DESCRIPTION
## Summary

Adds support for resolving `IfcTrimmedCurve` segments backed by `IfcLine`, including numeric parameter trims and cartesian point trims.

Registers a new Trimmed Line example in the app so users can inspect parameter-based line trimming, sense agreement, and trims that extend beyond the displayed magnitude guide.

## Impact

Users can now explore `IfcTrimmedCurve + IfcLine` behavior alongside the existing circle and ellipse trimmed-curve examples.

## Validation

- `bun run build`