### PR TITLE
Implement IfcPolynomialCurve rendering

### DIFF
--- a/scripts/generate_ifc_schema.py
+++ b/scripts/generate_ifc_schema.py
@@ -67,6 +67,7 @@ SUPPORTED_CURVE_ENTITIES = [
     "IfcCircle",
     "IfcEllipse",
     "IfcTrimmedCurve",
+    "IfcPolynomialCurve",
     "IfcCompositeCurve",
 ]
 

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -20,6 +20,7 @@ import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
 import { curveLineSample } from "../ifc/samples/curve.line.ts";
+import { curvePolynomialSample } from "../ifc/samples/curve.polynomial.ts";
 import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
 import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
 import { curveTrimmedCircleSample } from "../ifc/samples/curve.trimmed-circle.ts";
@@ -31,6 +32,7 @@ const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
   "curve-line": curveLineSample,
+  "curve-polynomial": curvePolynomialSample,
   "curve-circle": curveCircleSample,
   "curve-ellipse": curveEllipseSample,
   "curve-trimmed-circle": curveTrimmedCircleSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -160,6 +160,20 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
+    hash: "#/examples/curve-polynomial",
+    title: "Polynomial Curve",
+    description:
+      "Display an unbounded IfcPolynomialCurve inside a local origin-centered region.",
+    sampleId: "curve-polynomial",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "primary",
+    status: "available",
+    entity: "IfcPolynomialCurve",
+    dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
+  },
+  {
     hash: "#/examples/curve-circle",
     title: "Circle",
     description:
@@ -540,6 +554,15 @@ export const implementationMap: ImplementationMapItem[] = [
     description:
       "Infinite line represented from Pnt and Dir, with Magnitude used as the standalone display segment.",
     routeHash: "#/examples/curve-line",
+    dependsOn: ["IfcCurve"],
+  },
+  {
+    entity: "IfcPolynomialCurve",
+    domain: "Curves",
+    status: "available",
+    description:
+      "Unbounded polynomial curve displayed inside a local origin-centered X/Y/Z region before placement transform.",
+    routeHash: "#/examples/curve-polynomial",
     dependsOn: ["IfcCurve"],
   },
   {

--- a/src/ifc/generated/schema.ts
+++ b/src/ifc/generated/schema.ts
@@ -417,6 +417,7 @@ export type IfcSupportedCurve =
   | IfcCircle
   | IfcEllipse
   | IfcTrimmedCurve
+  | IfcPolynomialCurve
   | IfcCompositeCurve;
 
 // ── Parameterized profile definitions ────────────────────────────

--- a/src/ifc/operations/curve-polynomial.ts
+++ b/src/ifc/operations/curve-polynomial.ts
@@ -1,0 +1,252 @@
+import type { IfcPlacement, IfcPolynomialCurve } from "../generated/schema.ts";
+import {
+  normalizePlacement2D,
+  normalizePlacement3D,
+  type NormalizedPlacement2D,
+  type NormalizedPlacement3D,
+  type NormalizedVec3,
+} from "../normalize.ts";
+import type { Vec3 } from "../../types.ts";
+import type { ResolvedCurveSegment } from "./curve-types.ts";
+
+export const POLYNOMIAL_DISPLAY_MIN = -10;
+export const POLYNOMIAL_DISPLAY_MAX = 10;
+
+const DEFAULT_POLYNOMIAL_SEGMENTS = 192;
+const EPSILON = 1e-9;
+
+interface PolynomialCurveOptions {
+  displayMin?: number;
+  displayMax?: number;
+  segmentCount?: number;
+}
+
+function distance(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.hypot(dx, dy, dz);
+}
+
+function cross3(a: NormalizedVec3, b: NormalizedVec3): NormalizedVec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
+  const previous = points.at(-1);
+  if (!previous || !removeCoincident || distance(previous, point) > EPSILON) {
+    points.push(point);
+  }
+}
+
+function hasCoefficientSet(coefficients: number[] | undefined): boolean {
+  return Array.isArray(coefficients) && coefficients.length > 0;
+}
+
+function requirePolynomialCurveCondition(curve: IfcPolynomialCurve) {
+  const definedSetCount = [
+    curve.coefficientsX,
+    curve.coefficientsY,
+    curve.coefficientsZ,
+  ].filter(hasCoefficientSet).length;
+
+  if (definedSetCount < 2) {
+    throw new Error(
+      "IfcPolynomialCurve requires at least two coefficient sets among CoefficientsX, CoefficientsY, and CoefficientsZ",
+    );
+  }
+}
+
+function evaluatePolynomial(
+  coefficients: number[] | undefined,
+  parameter: number,
+): number {
+  let value = 0;
+  for (let index = (coefficients?.length ?? 0) - 1; index >= 0; index -= 1) {
+    value = value * parameter + (coefficients?.[index] ?? 0);
+  }
+  return value;
+}
+
+function evaluateLocalPoint(curve: IfcPolynomialCurve, parameter: number): Vec3 {
+  return {
+    x: evaluatePolynomial(curve.coefficientsX, parameter),
+    y: evaluatePolynomial(curve.coefficientsY, parameter),
+    z: evaluatePolynomial(curve.coefficientsZ, parameter),
+  };
+}
+
+function pointOnPlacement2D(
+  placement: NormalizedPlacement2D,
+  point: Vec3,
+): Vec3 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z: 0,
+  };
+}
+
+function pointOnPlacement3D(
+  placement: NormalizedPlacement3D,
+  point: Vec3,
+): Vec3 {
+  const yAxis = cross3(placement.zAxis, placement.xAxis);
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x +
+      point.z * placement.zAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y +
+      point.z * placement.zAxis.y,
+    z:
+      placement.origin.z +
+      point.x * placement.xAxis.z +
+      point.y * yAxis.z +
+      point.z * placement.zAxis.z,
+  };
+}
+
+export function polynomialLocalPointToWorld(
+  position: IfcPlacement,
+  point: Vec3,
+): Vec3 {
+  switch (position.type) {
+    case "IfcAxis2Placement2D":
+      return pointOnPlacement2D(normalizePlacement2D(position), point);
+    case "IfcAxis2Placement3D":
+      return pointOnPlacement3D(normalizePlacement3D(position), point);
+    default:
+      throw new Error(
+        `IfcPolynomialCurve position ${position.type} is not supported yet`,
+      );
+  }
+}
+
+function interpolate(a: Vec3, b: Vec3, ratio: number): Vec3 {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+    z: a.z + (b.z - a.z) * ratio,
+  };
+}
+
+function updateClipRange(
+  start: number,
+  delta: number,
+  min: number,
+  max: number,
+  range: { enter: number; exit: number },
+): boolean {
+  if (Math.abs(delta) < EPSILON) {
+    return start >= min && start <= max;
+  }
+
+  let near = (min - start) / delta;
+  let far = (max - start) / delta;
+  if (near > far) {
+    [near, far] = [far, near];
+  }
+
+  range.enter = Math.max(range.enter, near);
+  range.exit = Math.min(range.exit, far);
+  return range.enter <= range.exit;
+}
+
+function clipSegmentToBox(
+  start: Vec3,
+  end: Vec3,
+  min: number,
+  max: number,
+): [Vec3, Vec3] | undefined {
+  const range = { enter: 0, exit: 1 };
+
+  if (
+    !updateClipRange(start.x, end.x - start.x, min, max, range) ||
+    !updateClipRange(start.y, end.y - start.y, min, max, range) ||
+    !updateClipRange(start.z, end.z - start.z, min, max, range)
+  ) {
+    return undefined;
+  }
+
+  return [
+    interpolate(start, end, range.enter),
+    interpolate(start, end, range.exit),
+  ];
+}
+
+export function resolvePolynomialCurveSegments(
+  curve: IfcPolynomialCurve,
+  options: PolynomialCurveOptions = {},
+): ResolvedCurveSegment[] {
+  requirePolynomialCurveCondition(curve);
+
+  const displayMin = options.displayMin ?? POLYNOMIAL_DISPLAY_MIN;
+  const displayMax = options.displayMax ?? POLYNOMIAL_DISPLAY_MAX;
+  const segmentCount = Math.max(
+    1,
+    options.segmentCount ?? DEFAULT_POLYNOMIAL_SEGMENTS,
+  );
+  const delta = (displayMax - displayMin) / segmentCount;
+
+  const localPoints: Vec3[] = [];
+  for (let index = 0; index <= segmentCount; index += 1) {
+    localPoints.push(evaluateLocalPoint(curve, displayMin + delta * index));
+  }
+
+  const segments: ResolvedCurveSegment[] = [];
+  let currentPoints: Vec3[] = [];
+
+  for (let index = 0; index < localPoints.length - 1; index += 1) {
+    const clipped = clipSegmentToBox(
+      localPoints[index],
+      localPoints[index + 1],
+      displayMin,
+      displayMax,
+    );
+
+    if (!clipped) {
+      if (currentPoints.length >= 2) {
+        segments.push({ kind: "curve", points: currentPoints });
+      }
+      currentPoints = [];
+      continue;
+    }
+
+    const [localStart, localEnd] = clipped;
+    const worldStart = polynomialLocalPointToWorld(curve.position, localStart);
+    const worldEnd = polynomialLocalPointToWorld(curve.position, localEnd);
+    const previous = currentPoints.at(-1);
+
+    if (previous && distance(previous, worldStart) > EPSILON) {
+      if (currentPoints.length >= 2) {
+        segments.push({ kind: "curve", points: currentPoints });
+      }
+      currentPoints = [];
+    }
+
+    addCurvePoint(currentPoints, worldStart);
+    addCurvePoint(currentPoints, worldEnd);
+  }
+
+  if (currentPoints.length >= 2) {
+    segments.push({ kind: "curve", points: currentPoints });
+  }
+
+  return segments;
+}

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -6,6 +6,7 @@ import type {
   IfcEllipse,
   IfcIndexedPolyCurve,
   IfcLine,
+  IfcPolynomialCurve,
   IfcPolyline,
   IfcSegmentIndexSelect,
   IfcTrimmedCurve,
@@ -14,6 +15,7 @@ import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
 import { cartesianPointToVec3, resolveLineCurveSegment } from "./curve-line.ts";
+import { resolvePolynomialCurveSegments } from "./curve-polynomial.ts";
 import { resolveTrimmedCurveSegments } from "./curve-trimmed.ts";
 import type {
   IndexedPolyCurveResolvedSegment,
@@ -36,7 +38,8 @@ type RenderableCurve =
   | IfcCircle
   | IfcEllipse
   | IfcTrimmedCurve
-  | IfcLine;
+  | IfcLine
+  | IfcPolynomialCurve;
 
 function distance(a: Vec3, b: Vec3): number {
   const dx = a.x - b.x;
@@ -210,6 +213,8 @@ export function resolveSupportedCurveSegments(
       return resolveTrimmedCurveSegments(curve);
     case "IfcLine":
       return [resolveLineCurveSegment(curve)];
+    case "IfcPolynomialCurve":
+      return resolvePolynomialCurveSegments(curve);
     default: {
       const _exhaustive: never = curve;
       throw new Error(`Curve type is not supported yet: ${String(_exhaustive)}`);

--- a/src/ifc/samples/curve.polynomial.ts
+++ b/src/ifc/samples/curve.polynomial.ts
@@ -5,13 +5,16 @@ import type {
   IfcAxis2Placement3D,
   IfcProfileDef,
   ParamValues,
+  PolynomialCoefficients,
   SampleDef,
   SweepViewState,
   Vec3,
 } from "../../types.ts";
-import { getNumber } from "../../types.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
-import type { IfcPolynomialCurve } from "../generated/schema.ts";
+import type {
+  IfcIndexedPolyCurve,
+  IfcPolynomialCurve,
+} from "../generated/schema.ts";
 import { buildSupportedCurve } from "../operations/curve.ts";
 import {
   POLYNOMIAL_DISPLAY_MAX,
@@ -23,34 +26,26 @@ import {
   toIfcCurvePlacement,
 } from "./curve.conic.shared.ts";
 
-const COEFFICIENT_AXES = ["x", "y", "z"] as const;
-const COEFFICIENT_COUNT = 4;
+const DEFAULT_POLYNOMIAL_COEFFICIENTS: PolynomialCoefficients = {
+  x: [0, 1, 0, 0],
+  y: [0, -0.25, 0, 0.03],
+  z: [-3, 0, 0.06, 0],
+};
+
+function coefficientSet(coefficients: number[]): number[] | undefined {
+  return coefficients.length > 0 ? [...coefficients] : undefined;
+}
 
 function buildIfcPolynomialCurve(
-  params: ParamValues,
+  coefficients: PolynomialCoefficients,
   placement: IfcAxis2Placement3D,
 ): IfcPolynomialCurve {
   return {
     type: "IfcPolynomialCurve",
     position: toIfcCurvePlacement(placement),
-    coefficientsX: [
-      getNumber(params, "x0"),
-      getNumber(params, "x1"),
-      getNumber(params, "x2"),
-      getNumber(params, "x3"),
-    ],
-    coefficientsY: [
-      getNumber(params, "y0"),
-      getNumber(params, "y1"),
-      getNumber(params, "y2"),
-      getNumber(params, "y3"),
-    ],
-    coefficientsZ: [
-      getNumber(params, "z0"),
-      getNumber(params, "z1"),
-      getNumber(params, "z2"),
-      getNumber(params, "z3"),
-    ],
+    coefficientsX: coefficientSet(coefficients.x),
+    coefficientsY: coefficientSet(coefficients.y),
+    coefficientsZ: coefficientSet(coefficients.z),
   };
 }
 
@@ -99,34 +94,13 @@ function buildDisplayRegionBox(
   return box;
 }
 
-function buildCoefficientParameters(): SampleDef["parameters"] {
-  const defaults = {
-    x: [0, 1, 0, 0],
-    y: [0, -0.25, 0, 0.03],
-    z: [-3, 0, 0.06, 0],
-  } as const;
-
-  return COEFFICIENT_AXES.flatMap((axis) =>
-    Array.from({ length: COEFFICIENT_COUNT }, (_value, index) => ({
-      key: `${axis}${index}`,
-      label: `${axis.toUpperCase()} c${index}`,
-      type: "number" as const,
-      min: -5,
-      max: 5,
-      step: 0.01,
-      defaultValue: defaults[axis][index],
-      group: `Coefficients${axis.toUpperCase()}`,
-    })),
-  );
-}
-
 export const curvePolynomialSample: SampleDef = {
   id: "curve-polynomial",
   title: "Polynomial Curve (IfcPolynomialCurve)",
   description:
     "Inspect an unbounded IfcPolynomialCurve through coefficient sets for X, Y, and Z. " +
     "The standalone view clips the local curve to the origin-centered [-10, 10] display region before applying Position.",
-  parameters: buildCoefficientParameters(),
+  parameters: [],
   steps: [
     {
       id: "curve",
@@ -138,18 +112,28 @@ export const curvePolynomialSample: SampleDef = {
   placementEditorConfig: {
     defaultPlacement: DEFAULT_CURVE_PLACEMENT,
   },
+  polynomialCoefficientEditorConfig: {
+    defaultCoefficients: DEFAULT_POLYNOMIAL_COEFFICIENTS,
+    label: "Parameters",
+    step: 0.01,
+  },
   buildGeometry: (
     scene: Scene,
-    params: ParamValues,
+    _params: ParamValues,
     _stepIndex: number,
     _profile?: IfcProfileDef,
     _path?: Vec3[],
     _extrusion?: ExtrusionParams,
     placement?: IfcAxis2Placement3D,
     _sweepView?: SweepViewState,
+    _indexedPolyCurve?: IfcIndexedPolyCurve,
+    coefficients?: PolynomialCoefficients,
   ): Mesh[] => {
     const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
-    const curve = buildIfcPolynomialCurve(params, activePlacement);
+    const curve = buildIfcPolynomialCurve(
+      coefficients ?? DEFAULT_POLYNOMIAL_COEFFICIENTS,
+      activePlacement,
+    );
 
     return [
       buildDisplayRegionBox(scene, curve),
@@ -158,6 +142,9 @@ export const curvePolynomialSample: SampleDef = {
       }),
     ];
   },
-  getIFCRepresentation: (params: ParamValues) =>
-    buildIfcPolynomialCurve(params, DEFAULT_CURVE_PLACEMENT),
+  getIFCRepresentation: (_params: ParamValues) =>
+    buildIfcPolynomialCurve(
+      DEFAULT_POLYNOMIAL_COEFFICIENTS,
+      DEFAULT_CURVE_PLACEMENT,
+    ),
 };

--- a/src/ifc/samples/curve.polynomial.ts
+++ b/src/ifc/samples/curve.polynomial.ts
@@ -1,0 +1,180 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import type { IfcPolynomialCurve } from "../generated/schema.ts";
+import { buildSupportedCurve } from "../operations/curve.ts";
+import {
+  POLYNOMIAL_DISPLAY_MAX,
+  POLYNOMIAL_DISPLAY_MIN,
+  polynomialLocalPointToWorld,
+} from "../operations/curve-polynomial.ts";
+import {
+  DEFAULT_CURVE_PLACEMENT,
+  toIfcCurvePlacement,
+} from "./curve.conic.shared.ts";
+
+const COEFFICIENT_AXES = ["x", "y", "z"] as const;
+const COEFFICIENT_COUNT = 4;
+
+function buildIfcPolynomialCurve(
+  params: ParamValues,
+  placement: IfcAxis2Placement3D,
+): IfcPolynomialCurve {
+  return {
+    type: "IfcPolynomialCurve",
+    position: toIfcCurvePlacement(placement),
+    coefficientsX: [
+      getNumber(params, "x0"),
+      getNumber(params, "x1"),
+      getNumber(params, "x2"),
+      getNumber(params, "x3"),
+    ],
+    coefficientsY: [
+      getNumber(params, "y0"),
+      getNumber(params, "y1"),
+      getNumber(params, "y2"),
+      getNumber(params, "y3"),
+    ],
+    coefficientsZ: [
+      getNumber(params, "z0"),
+      getNumber(params, "z1"),
+      getNumber(params, "z2"),
+      getNumber(params, "z3"),
+    ],
+  };
+}
+
+function buildPlacementMarker(scene: Scene, placement: IfcAxis2Placement3D): Mesh {
+  const marker = MeshBuilder.CreateSphere(
+    "curve_polynomial_origin",
+    { diameter: 0.24, segments: 16 },
+    scene,
+  );
+  marker.position = ifcToBabylonVector(placement.location);
+  marker.material = getOrCreateSolidMaterial(
+    scene,
+    "curve_polynomial_origin_material",
+    new Color3(1, 0.75, 0.2),
+  );
+  return marker;
+}
+
+function buildDisplayRegionBox(
+  scene: Scene,
+  curve: IfcPolynomialCurve,
+): Mesh {
+  const min = POLYNOMIAL_DISPLAY_MIN;
+  const max = POLYNOMIAL_DISPLAY_MAX;
+  const corners: Vec3[] = [
+    { x: min, y: min, z: min },
+    { x: max, y: min, z: min },
+    { x: max, y: max, z: min },
+    { x: min, y: max, z: min },
+    { x: min, y: min, z: max },
+    { x: max, y: min, z: max },
+    { x: max, y: max, z: max },
+    { x: min, y: max, z: max },
+  ].map((point) => polynomialLocalPointToWorld(curve.position, point));
+  const edges = [
+    [0, 1],
+    [1, 2],
+    [2, 3],
+    [3, 0],
+    [4, 5],
+    [5, 6],
+    [6, 7],
+    [7, 4],
+    [0, 4],
+    [1, 5],
+    [2, 6],
+    [3, 7],
+  ] as const;
+
+  const box = MeshBuilder.CreateLineSystem(
+    "curve_polynomial_display_region",
+    {
+      lines: edges.map(([start, end]) => [
+        ifcToBabylonVector(corners[start]),
+        ifcToBabylonVector(corners[end]),
+      ]),
+    },
+    scene,
+  );
+  box.color = new Color3(0.45, 0.5, 0.56);
+  return box;
+}
+
+function buildCoefficientParameters(): SampleDef["parameters"] {
+  const defaults = {
+    x: [0, 1, 0, 0],
+    y: [0, -0.25, 0, 0.03],
+    z: [-3, 0, 0.06, 0],
+  } as const;
+
+  return COEFFICIENT_AXES.flatMap((axis) =>
+    Array.from({ length: COEFFICIENT_COUNT }, (_value, index) => ({
+      key: `${axis}${index}`,
+      label: `${axis.toUpperCase()} c${index}`,
+      type: "number" as const,
+      min: -5,
+      max: 5,
+      step: 0.01,
+      defaultValue: defaults[axis][index],
+      group: `Coefficients${axis.toUpperCase()}`,
+    })),
+  );
+}
+
+export const curvePolynomialSample: SampleDef = {
+  id: "curve-polynomial",
+  title: "Polynomial Curve (IfcPolynomialCurve)",
+  description:
+    "Inspect an unbounded IfcPolynomialCurve through coefficient sets for X, Y, and Z. " +
+    "The standalone view clips the local curve to the origin-centered [-10, 10] display region before applying Position.",
+  parameters: buildCoefficientParameters(),
+  steps: [
+    {
+      id: "curve",
+      label: "IfcPolynomialCurve",
+      description:
+        "At least two coefficient sets are provided, then the local polynomial curve is displayed within the origin-centered X/Y/Z range and transformed by Position.",
+    },
+  ],
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    _stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+  ): Mesh[] => {
+    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
+    const curve = buildIfcPolynomialCurve(params, activePlacement);
+
+    return [
+      buildDisplayRegionBox(scene, curve),
+      buildPlacementMarker(scene, activePlacement),
+      ...buildSupportedCurve(scene, curve, "curve_polynomial_result", {
+        curveColor: new Color3(0.35, 0.85, 0.95),
+      }),
+    ];
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildIfcPolynomialCurve(params, DEFAULT_CURVE_PLACEMENT),
+};

--- a/src/ifc/samples/curve.polynomial.ts
+++ b/src/ifc/samples/curve.polynomial.ts
@@ -10,7 +10,6 @@ import type {
   Vec3,
 } from "../../types.ts";
 import { getNumber } from "../../types.ts";
-import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { IfcPolynomialCurve } from "../generated/schema.ts";
 import { buildSupportedCurve } from "../operations/curve.ts";
@@ -53,21 +52,6 @@ function buildIfcPolynomialCurve(
       getNumber(params, "z3"),
     ],
   };
-}
-
-function buildPlacementMarker(scene: Scene, placement: IfcAxis2Placement3D): Mesh {
-  const marker = MeshBuilder.CreateSphere(
-    "curve_polynomial_origin",
-    { diameter: 0.24, segments: 16 },
-    scene,
-  );
-  marker.position = ifcToBabylonVector(placement.location);
-  marker.material = getOrCreateSolidMaterial(
-    scene,
-    "curve_polynomial_origin_material",
-    new Color3(1, 0.75, 0.2),
-  );
-  return marker;
 }
 
 function buildDisplayRegionBox(
@@ -169,7 +153,6 @@ export const curvePolynomialSample: SampleDef = {
 
     return [
       buildDisplayRegionBox(scene, curve),
-      buildPlacementMarker(scene, activePlacement),
       ...buildSupportedCurve(scene, curve, "curve_polynomial_result", {
         curveColor: new Color3(0.35, 0.85, 0.95),
       }),

--- a/src/pages/ExamplePage.ts
+++ b/src/pages/ExamplePage.ts
@@ -338,6 +338,7 @@ export class ExamplePage {
         polynomialCoefficientEditorContainer,
         sample.polynomialCoefficientEditorConfig,
       );
+      this.currentPolynomialCoefficients = coefficientEditor.getCoefficients();
       coefficientEditor.onChange((coefficients) => {
         this.currentPolynomialCoefficients = coefficients;
         this._scheduleRebuild(sample.debounceMs ?? 0);

--- a/src/pages/ExamplePage.ts
+++ b/src/pages/ExamplePage.ts
@@ -7,6 +7,7 @@ import type {
   ExtrusionParams,
   Vec3,
   SweepViewState,
+  PolynomialCoefficients,
 } from "../types.ts";
 import type { IfcIndexedPolyCurve } from "../ifc/generated/schema.ts";
 import { SceneManager } from "../engine/scene.ts";
@@ -20,6 +21,7 @@ import { IndexedPolyCurveEditor } from "../ui/IndexedPolyCurveEditor.ts";
 import { ExtrusionEditor } from "../ui/ExtrusionEditor.ts";
 import { PlacementEditor } from "../ui/PlacementEditor.ts";
 import { SweepViewToggles } from "../ui/SweepViewToggles.ts";
+import { PolynomialCoefficientEditor } from "../ui/PolynomialCoefficientEditor.ts";
 import { buildPlacementAxesOverlay } from "../engine/overlays.ts";
 
 export class ExamplePage {
@@ -37,6 +39,8 @@ export class ExamplePage {
   private currentExtrusion: ExtrusionParams | undefined = undefined;
   private currentPlacement: IfcAxis2Placement3D | undefined = undefined;
   private currentSweepView: SweepViewState | undefined = undefined;
+  private currentPolynomialCoefficients: PolynomialCoefficients | undefined =
+    undefined;
   private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(appContainer: HTMLElement) {
@@ -81,6 +85,14 @@ export class ExamplePage {
         ) as IfcAxis2Placement3D)
       : undefined;
 
+    this.currentPolynomialCoefficients = sample.polynomialCoefficientEditorConfig
+      ? (JSON.parse(
+          JSON.stringify(
+            sample.polynomialCoefficientEditorConfig.defaultCoefficients,
+          ),
+        ) as PolynomialCoefficients)
+      : undefined;
+
     // Seed sweep view state from config defaults (if any)
     this.currentSweepView = sample.sweepViewConfig
       ? {
@@ -95,6 +107,9 @@ export class ExamplePage {
     const hasIndexedPolyCurveEditor = Boolean(sample.indexedPolyCurveEditorConfig);
     const hasExtrusionEditor = Boolean(sample.extrusionEditorConfig);
     const hasPlacementEditor = Boolean(sample.placementEditorConfig);
+    const hasPolynomialCoefficientEditor = Boolean(
+      sample.polynomialCoefficientEditorConfig,
+    );
     const hasSweepToggles = Boolean(sample.sweepViewConfig);
 
     this.appContainer.innerHTML = `
@@ -169,9 +184,19 @@ export class ExamplePage {
                 : ""
             }
             ${
+              hasPolynomialCoefficientEditor
+                ? `
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}" open>
+                <summary class="params-title">${sample.polynomialCoefficientEditorConfig!.label ?? "Coefficients"}</summary>
+                <div class="left-collapsible-content" id="polynomial-coefficient-editor-panel"></div>
+              </details>
+            `
+                : ""
+            }
+            ${
               hasPlacementEditor
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasPolynomialCoefficientEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
                 <summary class="params-title">${sample.placementEditorConfig!.label ?? "Placement"}</summary>
                 <div class="left-collapsible-content" id="placement-editor-panel"></div>
               </details>
@@ -302,6 +327,23 @@ export class ExamplePage {
       });
     }
 
+    const polynomialCoefficientEditorContainer = document.getElementById(
+      "polynomial-coefficient-editor-panel",
+    );
+    if (
+      polynomialCoefficientEditorContainer &&
+      sample.polynomialCoefficientEditorConfig
+    ) {
+      const coefficientEditor = new PolynomialCoefficientEditor(
+        polynomialCoefficientEditorContainer,
+        sample.polynomialCoefficientEditorConfig,
+      );
+      coefficientEditor.onChange((coefficients) => {
+        this.currentPolynomialCoefficients = coefficients;
+        this._scheduleRebuild(sample.debounceMs ?? 0);
+      });
+    }
+
     const stepperContainer = document.getElementById("stepper")!;
     const stepper = new Stepper(stepperContainer, sample.steps);
 
@@ -346,6 +388,7 @@ export class ExamplePage {
       this.currentPlacement,
       this.currentSweepView,
       this.currentIndexedPolyCurve,
+      this.currentPolynomialCoefficients,
     );
 
     // Show local coordinate axes when a placement editor is active

--- a/src/style.css
+++ b/src/style.css
@@ -779,6 +779,42 @@ a.map-entity:hover {
   border-color: #4fc3f7;
 }
 
+/* Polynomial coefficient editor */
+.polynomial-coefficient-editor {
+  margin-bottom: 4px;
+}
+
+.coefficient-axis-section + .coefficient-axis-section {
+  margin-top: 12px;
+}
+
+.coefficient-axis-heading {
+  border-bottom: 1px solid #1a2a4a;
+  padding-bottom: 3px;
+}
+
+.coefficient-values-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 6px 0;
+}
+
+.coefficient-row .point-index {
+  width: 24px;
+}
+
+.coefficient-value-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.coefficient-empty-state {
+  color: #6a8aaa;
+  font-size: 0.76em;
+  padding: 2px 0 4px;
+}
+
 /* Indexed PolyCurve Editor */
 .indexed-polycurve-editor {
   margin-bottom: 4px;

--- a/src/style.css
+++ b/src/style.css
@@ -809,12 +809,6 @@ a.map-entity:hover {
   min-width: 0;
 }
 
-.coefficient-empty-state {
-  color: #6a8aaa;
-  font-size: 0.76em;
-  padding: 2px 0 4px;
-}
-
 /* Indexed PolyCurve Editor */
 .indexed-polycurve-editor {
   margin-bottom: 4px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,24 @@ export interface PlacementEditorConfig {
   label?: string;
 }
 
+export type PolynomialCoefficientAxis = "x" | "y" | "z";
+
+export interface PolynomialCoefficients {
+  x: number[];
+  y: number[];
+  z: number[];
+}
+
+/** Configuration for editing IfcPolynomialCurve coefficient arrays. */
+export interface PolynomialCoefficientEditorConfig {
+  /** Initial coefficient arrays for X, Y, and Z. */
+  defaultCoefficients: PolynomialCoefficients;
+  /** Optional label shown above the editor. */
+  label?: string;
+  /** Numeric input step for coefficient values. */
+  step?: number;
+}
+
 /** Visibility flags passed to buildGeometry for sweep-based samples. */
 export interface SweepViewState {
   showPath: boolean;
@@ -292,6 +310,11 @@ export interface SampleDef {
    */
   placementEditorConfig?: PlacementEditorConfig;
   /**
+   * When set, ExamplePage renders coefficient editors for IfcPolynomialCurve.
+   * The current arrays are forwarded to buildGeometry as the optional tenth argument.
+   */
+  polynomialCoefficientEditorConfig?: PolynomialCoefficientEditorConfig;
+  /**
    * When set, ExamplePage renders sweep-view toggle buttons (path / local
    * frames / result). The current SweepViewState is forwarded to buildGeometry
    * as the optional eighth argument.
@@ -307,6 +330,7 @@ export interface SampleDef {
     placement?: IfcAxis2Placement3D,
     sweepView?: SweepViewState,
     indexedPolyCurve?: IfcIndexedPolyCurve,
+    polynomialCoefficients?: PolynomialCoefficients,
   ) => Mesh[];
   getIFCRepresentation: (params: ParamValues) => object;
 }

--- a/src/ui/PolynomialCoefficientEditor.ts
+++ b/src/ui/PolynomialCoefficientEditor.ts
@@ -1,0 +1,185 @@
+import type {
+  PolynomialCoefficientAxis,
+  PolynomialCoefficientEditorConfig,
+  PolynomialCoefficients,
+} from "../types.ts";
+
+const AXES: Array<{
+  key: PolynomialCoefficientAxis;
+  label: string;
+  group: string;
+}> = [
+  { key: "x", label: "X", group: "CoefficientsX" },
+  { key: "y", label: "Y", group: "CoefficientsY" },
+  { key: "z", label: "Z", group: "CoefficientsZ" },
+];
+
+const DEFAULT_COEFFICIENT_STEP = 0.01;
+
+function cloneCoefficients(
+  coefficients: PolynomialCoefficients,
+): PolynomialCoefficients {
+  return {
+    x: [...coefficients.x],
+    y: [...coefficients.y],
+    z: [...coefficients.z],
+  };
+}
+
+export class PolynomialCoefficientEditor {
+  private container: HTMLElement;
+  private config: PolynomialCoefficientEditorConfig;
+  private coefficients: PolynomialCoefficients;
+  private changeCallbacks: Array<(coefficients: PolynomialCoefficients) => void> =
+    [];
+
+  constructor(
+    container: HTMLElement,
+    config: PolynomialCoefficientEditorConfig,
+  ) {
+    this.container = container;
+    this.config = config;
+    this.coefficients = cloneCoefficients(config.defaultCoefficients);
+    this._render();
+  }
+
+  getCoefficients(): PolynomialCoefficients {
+    return cloneCoefficients(this.coefficients);
+  }
+
+  onChange(callback: (coefficients: PolynomialCoefficients) => void): void {
+    this.changeCallbacks.push(callback);
+  }
+
+  private _notify(): void {
+    const copy = this.getCoefficients();
+    for (const callback of this.changeCallbacks) callback(copy);
+  }
+
+  private _render(): void {
+    this.container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "polynomial-coefficient-editor";
+
+    for (const axis of AXES) {
+      wrapper.appendChild(this._buildAxisSection(axis.key, axis.label, axis.group));
+    }
+
+    this.container.appendChild(wrapper);
+  }
+
+  private _buildAxisSection(
+    axis: PolynomialCoefficientAxis,
+    axisLabel: string,
+    groupLabel: string,
+  ): HTMLElement {
+    const section = document.createElement("section");
+    section.className = "coefficient-axis-section";
+
+    const heading = document.createElement("div");
+    heading.className = "param-label coefficient-axis-heading";
+    heading.textContent = groupLabel;
+    section.appendChild(heading);
+
+    const list = document.createElement("div");
+    list.className = "coefficient-values-list";
+
+    this.coefficients[axis].forEach((value, index) => {
+      list.appendChild(this._buildCoefficientRow(axis, axisLabel, value, index));
+    });
+
+    if (this.coefficients[axis].length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "coefficient-empty-state";
+      empty.textContent = "No coefficients";
+      list.appendChild(empty);
+    }
+
+    section.appendChild(list);
+
+    const addBtn = document.createElement("button");
+    addBtn.type = "button";
+    addBtn.className = "path-add-point-btn";
+    addBtn.textContent = `+ Add ${axisLabel} coefficient`;
+    addBtn.addEventListener("click", () => {
+      this.coefficients[axis].push(0);
+      this._refresh();
+      this._notify();
+    });
+    section.appendChild(addBtn);
+
+    return section;
+  }
+
+  private _buildCoefficientRow(
+    axis: PolynomialCoefficientAxis,
+    axisLabel: string,
+    value: number,
+    index: number,
+  ): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "path-point-row coefficient-row";
+
+    const idx = document.createElement("span");
+    idx.className = "point-index";
+    idx.textContent = `c${index}`;
+    row.appendChild(idx);
+
+    const label = document.createElement("span");
+    label.className = "point-coord-label";
+    label.textContent = axisLabel;
+    row.appendChild(label);
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.className = "point-coord-input coefficient-value-input";
+    input.value = String(value);
+    input.step = String(this.config.step ?? DEFAULT_COEFFICIENT_STEP);
+    input.addEventListener("input", () => {
+      const parsed = Number(input.value);
+      if (Number.isFinite(parsed)) {
+        this.coefficients[axis][index] = parsed;
+        this._notify();
+      }
+    });
+    row.appendChild(input);
+
+    if (this._canRemoveCoefficient(axis)) {
+      const del = document.createElement("button");
+      del.type = "button";
+      del.className = "point-delete-btn";
+      del.title = "Remove coefficient";
+      del.textContent = "x";
+      del.addEventListener("click", () => {
+        this.coefficients[axis].splice(index, 1);
+        this._refresh();
+        this._notify();
+      });
+      row.appendChild(del);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    return row;
+  }
+
+  private _canRemoveCoefficient(axis: PolynomialCoefficientAxis): boolean {
+    const axisLength = this.coefficients[axis].length;
+    if (axisLength > 1) return true;
+    if (axisLength === 0) return false;
+
+    const remainingDefinedAxes = AXES.filter(({ key }) => {
+      if (key === axis) return false;
+      return this.coefficients[key].length > 0;
+    }).length;
+
+    return remainingDefinedAxes >= 2;
+  }
+
+  private _refresh(): void {
+    this._render();
+  }
+}

--- a/src/ui/PolynomialCoefficientEditor.ts
+++ b/src/ui/PolynomialCoefficientEditor.ts
@@ -152,7 +152,7 @@ export class PolynomialCoefficientEditor {
       del.type = "button";
       del.className = "point-delete-btn";
       del.title = "Remove coefficient";
-      del.textContent = "x";
+      del.textContent = "×";
       del.addEventListener("click", () => {
         this.coefficients[axis].splice(index, 1);
         this._refresh();

--- a/src/ui/PolynomialCoefficientEditor.ts
+++ b/src/ui/PolynomialCoefficientEditor.ts
@@ -15,14 +15,23 @@ const AXES: Array<{
 ];
 
 const DEFAULT_COEFFICIENT_STEP = 0.01;
+const MIN_COEFFICIENT_COUNT = 2;
 
 function cloneCoefficients(
   coefficients: PolynomialCoefficients,
 ): PolynomialCoefficients {
+  const ensureMinimumLength = (values: number[]): number[] => {
+    const normalized = [...values];
+    while (normalized.length < MIN_COEFFICIENT_COUNT) {
+      normalized.push(0);
+    }
+    return normalized;
+  };
+
   return {
-    x: [...coefficients.x],
-    y: [...coefficients.y],
-    z: [...coefficients.z],
+    x: ensureMinimumLength(coefficients.x),
+    y: ensureMinimumLength(coefficients.y),
+    z: ensureMinimumLength(coefficients.z),
   };
 }
 
@@ -89,13 +98,6 @@ export class PolynomialCoefficientEditor {
       list.appendChild(this._buildCoefficientRow(axis, axisLabel, value, index));
     });
 
-    if (this.coefficients[axis].length === 0) {
-      const empty = document.createElement("div");
-      empty.className = "coefficient-empty-state";
-      empty.textContent = "No coefficients";
-      list.appendChild(empty);
-    }
-
     section.appendChild(list);
 
     const addBtn = document.createElement("button");
@@ -145,7 +147,7 @@ export class PolynomialCoefficientEditor {
     });
     row.appendChild(input);
 
-    if (this._canRemoveCoefficient(axis)) {
+    if (this._canRemoveCoefficient(axis, index)) {
       const del = document.createElement("button");
       del.type = "button";
       del.className = "point-delete-btn";
@@ -166,17 +168,14 @@ export class PolynomialCoefficientEditor {
     return row;
   }
 
-  private _canRemoveCoefficient(axis: PolynomialCoefficientAxis): boolean {
-    const axisLength = this.coefficients[axis].length;
-    if (axisLength > 1) return true;
-    if (axisLength === 0) return false;
-
-    const remainingDefinedAxes = AXES.filter(({ key }) => {
-      if (key === axis) return false;
-      return this.coefficients[key].length > 0;
-    }).length;
-
-    return remainingDefinedAxes >= 2;
+  private _canRemoveCoefficient(
+    axis: PolynomialCoefficientAxis,
+    index: number,
+  ): boolean {
+    return (
+      index >= MIN_COEFFICIENT_COUNT &&
+      this.coefficients[axis].length > MIN_COEFFICIENT_COUNT
+    );
   }
 
   private _refresh(): void {


### PR DESCRIPTION
## Summary

- Add IfcPolynomialCurve support to the curve resolver and supported schema list.
- Render the unbounded polynomial curve within the local [-10, 10] display region, then apply Position placement transforms.
- Add a Polynomial Curve sample route with an editable coefficient UI for CoefficientsX, CoefficientsY, and CoefficientsZ.
- Keep c0 and c1 required for each coefficient array while allowing later coefficients to be added or removed independently.

## Validation

- `bun run build`