### PR TITLE
[codex] Implement IfcClothoid curve sample

### DIFF
--- a/scripts/generate_ifc_schema.py
+++ b/scripts/generate_ifc_schema.py
@@ -68,6 +68,7 @@ SUPPORTED_CURVE_ENTITIES = [
     "IfcEllipse",
     "IfcTrimmedCurve",
     "IfcPolynomialCurve",
+    "IfcClothoid",
     "IfcCompositeCurve",
 ]
 

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -21,6 +21,7 @@ import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
 import { curveLineSample } from "../ifc/samples/curve.line.ts";
 import { curvePolynomialSample } from "../ifc/samples/curve.polynomial.ts";
+import { curveClothoidSample } from "../ifc/samples/curve.clothoid.ts";
 import { curveCircleSample } from "../ifc/samples/curve.circle.ts";
 import { curveEllipseSample } from "../ifc/samples/curve.ellipse.ts";
 import { curveTrimmedCircleSample } from "../ifc/samples/curve.trimmed-circle.ts";
@@ -33,6 +34,7 @@ const samples: Record<string, SampleDef> = {
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
   "curve-line": curveLineSample,
   "curve-polynomial": curvePolynomialSample,
+  "curve-clothoid": curveClothoidSample,
   "curve-circle": curveCircleSample,
   "curve-ellipse": curveEllipseSample,
   "curve-trimmed-circle": curveTrimmedCircleSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -174,6 +174,20 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
+    hash: "#/examples/curve-clothoid",
+    title: "Clothoid",
+    description:
+      "Display an unbounded IfcClothoid inside a local origin-centered region.",
+    sampleId: "curve-clothoid",
+    domain: "Curves",
+    difficulty: "intermediate",
+    exampleKind: "primary",
+    status: "available",
+    entity: "IfcClothoid",
+    dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
+  },
+  {
     hash: "#/examples/curve-circle",
     title: "Circle",
     description:

--- a/src/ifc/generated/schema.ts
+++ b/src/ifc/generated/schema.ts
@@ -418,6 +418,7 @@ export type IfcSupportedCurve =
   | IfcEllipse
   | IfcTrimmedCurve
   | IfcPolynomialCurve
+  | IfcClothoid
   | IfcCompositeCurve;
 
 // ── Parameterized profile definitions ────────────────────────────

--- a/src/ifc/operations/curve-clothoid.ts
+++ b/src/ifc/operations/curve-clothoid.ts
@@ -1,0 +1,263 @@
+import type {
+  IfcAxis2Placement2D,
+  IfcAxis2Placement3D,
+  IfcClothoid,
+} from "../generated/schema.ts";
+import {
+  normalizePlacement2D,
+  normalizePlacement3D,
+  type NormalizedPlacement2D,
+  type NormalizedPlacement3D,
+  type NormalizedVec3,
+} from "../normalize.ts";
+import type { Vec3 } from "../../types.ts";
+import type { ResolvedCurveSegment } from "./curve-types.ts";
+
+export const CLOTHOID_DISPLAY_MIN = -10;
+export const CLOTHOID_DISPLAY_MAX = 10;
+
+const DEFAULT_CLOTHOID_SEGMENTS = 256;
+const INTEGRATION_STEPS_PER_UNIT = 64;
+const EPSILON = 1e-9;
+
+interface ClothoidCurveOptions {
+  displayMin?: number;
+  displayMax?: number;
+  segmentCount?: number;
+}
+
+type ClothoidPlacement = IfcAxis2Placement2D | IfcAxis2Placement3D;
+
+function distance(a: Vec3, b: Vec3): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = a.z - b.z;
+  return Math.hypot(dx, dy, dz);
+}
+
+function cross3(a: NormalizedVec3, b: NormalizedVec3): NormalizedVec3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function addCurvePoint(points: Vec3[], point: Vec3, removeCoincident = true) {
+  const previous = points.at(-1);
+  if (!previous || !removeCoincident || distance(previous, point) > EPSILON) {
+    points.push(point);
+  }
+}
+
+function requireClothoidConstant(curve: IfcClothoid) {
+  if (Math.abs(curve.clothoidConstant) < EPSILON) {
+    throw new Error("IfcClothoid requires a non-zero ClothoidConstant");
+  }
+}
+
+function evaluateLocalPoint(curve: IfcClothoid, parameter: number): Vec3 {
+  if (Math.abs(parameter) < EPSILON) {
+    return { x: 0, y: 0, z: 0 };
+  }
+
+  const a = curve.clothoidConstant;
+  const aSquared = a * a;
+  const sign = a >= 0 ? 1 : -1;
+  const steps = Math.max(
+    16,
+    Math.ceil(Math.abs(parameter) * INTEGRATION_STEPS_PER_UNIT),
+  );
+  const ds = parameter / steps;
+
+  let currentS = 0;
+  let currentTheta = 0;
+  let x = 0;
+  let y = 0;
+
+  for (let index = 0; index < steps; index += 1) {
+    const dTheta =
+      sign * (currentS * ds / aSquared + (ds * ds) / (2 * aSquared));
+    const thetaMid = currentTheta + dTheta / 2;
+
+    x += ds * Math.cos(thetaMid);
+    y += ds * Math.sin(thetaMid);
+    currentTheta += dTheta;
+    currentS += ds;
+  }
+
+  return { x, y, z: 0 };
+}
+
+function pointOnPlacement2D(
+  placement: NormalizedPlacement2D,
+  point: Vec3,
+): Vec3 {
+  const yAxis = { x: -placement.xAxis.y, y: placement.xAxis.x };
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y,
+    z: 0,
+  };
+}
+
+function pointOnPlacement3D(
+  placement: NormalizedPlacement3D,
+  point: Vec3,
+): Vec3 {
+  const yAxis = cross3(placement.zAxis, placement.xAxis);
+  return {
+    x:
+      placement.origin.x +
+      point.x * placement.xAxis.x +
+      point.y * yAxis.x +
+      point.z * placement.zAxis.x,
+    y:
+      placement.origin.y +
+      point.x * placement.xAxis.y +
+      point.y * yAxis.y +
+      point.z * placement.zAxis.y,
+    z:
+      placement.origin.z +
+      point.x * placement.xAxis.z +
+      point.y * yAxis.z +
+      point.z * placement.zAxis.z,
+  };
+}
+
+export function clothoidLocalPointToWorld(
+  position: ClothoidPlacement,
+  point: Vec3,
+): Vec3 {
+  switch (position.type) {
+    case "IfcAxis2Placement2D":
+      return pointOnPlacement2D(normalizePlacement2D(position), point);
+    case "IfcAxis2Placement3D":
+      return pointOnPlacement3D(normalizePlacement3D(position), point);
+    default: {
+      const _exhaustive: never = position;
+      throw new Error(
+        `IfcClothoid position is not supported yet: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+function interpolate(a: Vec3, b: Vec3, ratio: number): Vec3 {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+    z: a.z + (b.z - a.z) * ratio,
+  };
+}
+
+function updateClipRange(
+  start: number,
+  delta: number,
+  min: number,
+  max: number,
+  range: { enter: number; exit: number },
+): boolean {
+  if (Math.abs(delta) < EPSILON) {
+    return start >= min && start <= max;
+  }
+
+  let near = (min - start) / delta;
+  let far = (max - start) / delta;
+  if (near > far) {
+    [near, far] = [far, near];
+  }
+
+  range.enter = Math.max(range.enter, near);
+  range.exit = Math.min(range.exit, far);
+  return range.enter <= range.exit;
+}
+
+function clipSegmentToBox(
+  start: Vec3,
+  end: Vec3,
+  min: number,
+  max: number,
+): [Vec3, Vec3] | undefined {
+  const range = { enter: 0, exit: 1 };
+
+  if (
+    !updateClipRange(start.x, end.x - start.x, min, max, range) ||
+    !updateClipRange(start.y, end.y - start.y, min, max, range) ||
+    !updateClipRange(start.z, end.z - start.z, min, max, range)
+  ) {
+    return undefined;
+  }
+
+  return [
+    interpolate(start, end, range.enter),
+    interpolate(start, end, range.exit),
+  ];
+}
+
+export function resolveClothoidCurveSegments(
+  curve: IfcClothoid,
+  options: ClothoidCurveOptions = {},
+): ResolvedCurveSegment[] {
+  requireClothoidConstant(curve);
+
+  const displayMin = options.displayMin ?? CLOTHOID_DISPLAY_MIN;
+  const displayMax = options.displayMax ?? CLOTHOID_DISPLAY_MAX;
+  const segmentCount = Math.max(
+    1,
+    options.segmentCount ?? DEFAULT_CLOTHOID_SEGMENTS,
+  );
+  const delta = (displayMax - displayMin) / segmentCount;
+
+  const localPoints: Vec3[] = [];
+  for (let index = 0; index <= segmentCount; index += 1) {
+    localPoints.push(evaluateLocalPoint(curve, displayMin + delta * index));
+  }
+
+  const segments: ResolvedCurveSegment[] = [];
+  let currentPoints: Vec3[] = [];
+
+  for (let index = 0; index < localPoints.length - 1; index += 1) {
+    const clipped = clipSegmentToBox(
+      localPoints[index],
+      localPoints[index + 1],
+      displayMin,
+      displayMax,
+    );
+
+    if (!clipped) {
+      if (currentPoints.length >= 2) {
+        segments.push({ kind: "curve", points: currentPoints });
+      }
+      currentPoints = [];
+      continue;
+    }
+
+    const [localStart, localEnd] = clipped;
+    const worldStart = clothoidLocalPointToWorld(curve.position, localStart);
+    const worldEnd = clothoidLocalPointToWorld(curve.position, localEnd);
+    const previous = currentPoints.at(-1);
+
+    if (previous && distance(previous, worldStart) > EPSILON) {
+      if (currentPoints.length >= 2) {
+        segments.push({ kind: "curve", points: currentPoints });
+      }
+      currentPoints = [];
+    }
+
+    addCurvePoint(currentPoints, worldStart);
+    addCurvePoint(currentPoints, worldEnd);
+  }
+
+  if (currentPoints.length >= 2) {
+    segments.push({ kind: "curve", points: currentPoints });
+  }
+
+  return segments;
+}

--- a/src/ifc/operations/curve-clothoid.ts
+++ b/src/ifc/operations/curve-clothoid.ts
@@ -143,7 +143,7 @@ export function clothoidLocalPointToWorld(
     default: {
       const _exhaustive: never = position;
       throw new Error(
-        `IfcClothoid position is not supported yet: ${String(_exhaustive)}`,
+        `IfcClothoid position is not supported yet: ${(_exhaustive as { type: string }).type}`,
       );
     }
   }
@@ -215,9 +215,25 @@ export function resolveClothoidCurveSegments(
   );
   const delta = (displayMax - displayMin) / segmentCount;
 
-  const localPoints: Vec3[] = [];
-  for (let index = 0; index <= segmentCount; index += 1) {
-    localPoints.push(evaluateLocalPoint(curve, displayMin + delta * index));
+  const a = curve.clothoidConstant;
+  const aSquared = a * a;
+  const sign = a >= 0 ? 1 : -1;
+
+  // Seed the first point with a one-time integration from s=0 to displayMin.
+  const seed = evaluateLocalPoint(curve, displayMin);
+  let { x, y } = seed;
+
+  // Build subsequent points incrementally using the exact clothoid tangent angle
+  // theta(s) = sign * s² / (2A²), so each step is O(1) — total O(segmentCount).
+  const localPoints: Vec3[] = [{ x, y, z: 0 }];
+  let currentS = displayMin;
+  for (let index = 0; index < segmentCount; index += 1) {
+    const sMid = currentS + delta / 2;
+    const thetaMid = sign * (sMid * sMid) / (2 * aSquared);
+    x += delta * Math.cos(thetaMid);
+    y += delta * Math.sin(thetaMid);
+    currentS += delta;
+    localPoints.push({ x, y, z: 0 });
   }
 
   const segments: ResolvedCurveSegment[] = [];

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -3,6 +3,7 @@ import type { Scene, StandardMaterial } from "@babylonjs/core";
 import type {
   IfcCartesianPointList,
   IfcCircle,
+  IfcClothoid,
   IfcEllipse,
   IfcIndexedPolyCurve,
   IfcLine,
@@ -13,6 +14,7 @@ import type {
 } from "../generated/schema.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
+import { resolveClothoidCurveSegments } from "./curve-clothoid.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
 import { cartesianPointToVec3, resolveLineCurveSegment } from "./curve-line.ts";
 import { resolvePolynomialCurveSegments } from "./curve-polynomial.ts";
@@ -39,7 +41,8 @@ type RenderableCurve =
   | IfcEllipse
   | IfcTrimmedCurve
   | IfcLine
-  | IfcPolynomialCurve;
+  | IfcPolynomialCurve
+  | IfcClothoid;
 
 function distance(a: Vec3, b: Vec3): number {
   const dx = a.x - b.x;
@@ -215,6 +218,8 @@ export function resolveSupportedCurveSegments(
       return [resolveLineCurveSegment(curve)];
     case "IfcPolynomialCurve":
       return resolvePolynomialCurveSegments(curve);
+    case "IfcClothoid":
+      return resolveClothoidCurveSegments(curve);
     default: {
       const _exhaustive: never = curve;
       throw new Error(`Curve type is not supported yet: ${String(_exhaustive)}`);

--- a/src/ifc/samples/curve.clothoid.ts
+++ b/src/ifc/samples/curve.clothoid.ts
@@ -1,0 +1,140 @@
+import { Color3, MeshBuilder } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  PolynomialCoefficients,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import { getNumber } from "../../types.ts";
+import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
+import type {
+  IfcClothoid,
+  IfcIndexedPolyCurve,
+} from "../generated/schema.ts";
+import { buildSupportedCurve } from "../operations/curve.ts";
+import {
+  CLOTHOID_DISPLAY_MAX,
+  CLOTHOID_DISPLAY_MIN,
+  clothoidLocalPointToWorld,
+} from "../operations/curve-clothoid.ts";
+import {
+  DEFAULT_CURVE_PLACEMENT,
+  toIfcCurvePlacement,
+} from "./curve.conic.shared.ts";
+
+const DEFAULT_CLOTHOID_CONSTANT = 6;
+
+function buildIfcClothoid(
+  clothoidConstant: number,
+  placement: IfcAxis2Placement3D,
+): IfcClothoid {
+  return {
+    type: "IfcClothoid",
+    position: toIfcCurvePlacement(placement),
+    clothoidConstant,
+  };
+}
+
+function buildDisplayRegionBox(scene: Scene, curve: IfcClothoid): Mesh {
+  const min = CLOTHOID_DISPLAY_MIN;
+  const max = CLOTHOID_DISPLAY_MAX;
+  const corners: Vec3[] = [
+    { x: min, y: min, z: min },
+    { x: max, y: min, z: min },
+    { x: max, y: max, z: min },
+    { x: min, y: max, z: min },
+    { x: min, y: min, z: max },
+    { x: max, y: min, z: max },
+    { x: max, y: max, z: max },
+    { x: min, y: max, z: max },
+  ].map((point) => clothoidLocalPointToWorld(curve.position, point));
+  const edges = [
+    [0, 1],
+    [1, 2],
+    [2, 3],
+    [3, 0],
+    [4, 5],
+    [5, 6],
+    [6, 7],
+    [7, 4],
+    [0, 4],
+    [1, 5],
+    [2, 6],
+    [3, 7],
+  ] as const;
+
+  const box = MeshBuilder.CreateLineSystem(
+    "curve_clothoid_display_region",
+    {
+      lines: edges.map(([start, end]) => [
+        ifcToBabylonVector(corners[start]),
+        ifcToBabylonVector(corners[end]),
+      ]),
+    },
+    scene,
+  );
+  box.color = new Color3(0.45, 0.5, 0.56);
+  return box;
+}
+
+export const curveClothoidSample: SampleDef = {
+  id: "curve-clothoid",
+  title: "Clothoid (IfcClothoid)",
+  description:
+    "Inspect an unbounded IfcClothoid within the origin-centered [-10, 10] local display region before applying Position.",
+  parameters: [
+    {
+      key: "clothoidConstant",
+      label: "Clothoid Constant",
+      type: "number",
+      min: 1,
+      max: 20,
+      step: 0.1,
+      defaultValue: DEFAULT_CLOTHOID_CONSTANT,
+    },
+  ],
+  steps: [
+    {
+      id: "curve",
+      label: "IfcClothoid",
+      description:
+        "The clothoid is sampled in a local origin-centered range, clipped to the local X/Y/Z display box, then transformed by Position.",
+    },
+  ],
+  placementEditorConfig: {
+    defaultPlacement: DEFAULT_CURVE_PLACEMENT,
+  },
+  buildGeometry: (
+    scene: Scene,
+    params: ParamValues,
+    _stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+    _indexedPolyCurve?: IfcIndexedPolyCurve,
+    _coefficients?: PolynomialCoefficients,
+  ): Mesh[] => {
+    const activePlacement = placement ?? DEFAULT_CURVE_PLACEMENT;
+    const clothoidConstant = getNumber(params, "clothoidConstant");
+    const curve = buildIfcClothoid(clothoidConstant, activePlacement);
+
+    return [
+      buildDisplayRegionBox(scene, curve),
+      ...buildSupportedCurve(scene, curve, "curve_clothoid_result", {
+        curveColor: new Color3(0.36, 0.78, 0.42),
+      }),
+    ];
+  },
+  getIFCRepresentation: (params: ParamValues) =>
+    buildIfcClothoid(
+      getNumber(params, "clothoidConstant"),
+      DEFAULT_CURVE_PLACEMENT,
+    ),
+};


### PR DESCRIPTION
## Summary

- Add an IfcClothoid curve resolver that samples the unbounded clothoid in the local origin-centered `[-10, 10]` display region, clips to that box, then applies `Position`.
- Register IfcClothoid as a supported renderable curve and add a one-step sample page with a Clothoid Constant parameter and placement editor.
- Update the generated schema union and generator allowlist so IfcClothoid is part of the runtime-facing supported curve set.

## Validation

- `bun run build`