### PR TITLE
[codex] Implement IfcBSplineCurveWithKnots sample

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -19,6 +19,7 @@ import { sweptDiskBasicSample } from "../ifc/samples/swept-disk.basic.ts";
 import { revolvedRectangleSample } from "../ifc/samples/revolved.rectangle.ts";
 import { curvePolylineSample } from "../ifc/samples/curve.polyline.ts";
 import { curveIndexedPolyCurveSample } from "../ifc/samples/curve.indexed-polycurve.ts";
+import { curveBSplineWithKnotsSample } from "../ifc/samples/curve.bspline-with-knots.ts";
 import { curveLineSample } from "../ifc/samples/curve.line.ts";
 import { curvePolynomialSample } from "../ifc/samples/curve.polynomial.ts";
 import { curveClothoidSample } from "../ifc/samples/curve.clothoid.ts";
@@ -32,6 +33,7 @@ import type { SampleDef } from "../types.ts";
 const samples: Record<string, SampleDef> = {
   "curve-polyline": curvePolylineSample,
   "curve-indexed-polycurve": curveIndexedPolyCurveSample,
+  "curve-bspline-with-knots": curveBSplineWithKnotsSample,
   "curve-line": curveLineSample,
   "curve-polynomial": curvePolynomialSample,
   "curve-clothoid": curveClothoidSample,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -146,6 +146,20 @@ export const routes: Route[] = [
     operationGroup: "curve-primitives",
   },
   {
+    hash: "#/examples/curve-bspline-with-knots",
+    title: "B-Spline With Knots",
+    description:
+      "Edit control points, knot multiplicities, and explicit knot values for an IfcBSplineCurveWithKnots.",
+    sampleId: "curve-bspline-with-knots",
+    domain: "Curves",
+    difficulty: "advanced",
+    exampleKind: "primary",
+    status: "available",
+    entity: "IfcBSplineCurveWithKnots",
+    dependsOn: ["IfcCurve"],
+    operationGroup: "curve-primitives",
+  },
+  {
     hash: "#/examples/curve-line",
     title: "Line",
     description:

--- a/src/ifc/operations/curve-bspline.ts
+++ b/src/ifc/operations/curve-bspline.ts
@@ -1,0 +1,193 @@
+import type { IfcBSplineCurveWithKnots } from "../generated/schema.ts";
+import type { Vec3 } from "../../types.ts";
+import type { ResolvedCurveSegment } from "./curve-types.ts";
+
+const DEFAULT_BSPLINE_SEGMENTS = 128;
+const EPSILON = 1e-9;
+
+export interface BSplineValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface BSplineCurveOptions {
+  segmentCount?: number;
+}
+
+function cartesianPointToVec3(point: { coordinates: number[] }): Vec3 {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
+}
+
+function expandKnots(
+  knotMultiplicities: readonly number[],
+  knots: readonly number[],
+): number[] {
+  const expanded: number[] = [];
+  const count = Math.min(knotMultiplicities.length, knots.length);
+
+  for (let index = 0; index < count; index += 1) {
+    const multiplicity = Math.max(0, Math.floor(knotMultiplicities[index]));
+    for (let repeat = 0; repeat < multiplicity; repeat += 1) {
+      expanded.push(knots[index]);
+    }
+  }
+
+  return expanded;
+}
+
+function interpolateVec3(a: Vec3, b: Vec3, ratio: number): Vec3 {
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio,
+    z: a.z + (b.z - a.z) * ratio,
+  };
+}
+
+function evaluateBSpline(
+  parameter: number,
+  degree: number,
+  controlPoints: readonly Vec3[],
+  expandedKnots: readonly number[],
+): Vec3 {
+  const domainLow = degree;
+  const domainHigh = expandedKnots.length - 1 - degree;
+  const low = expandedKnots[domainLow];
+  const high = expandedKnots[domainHigh];
+  const clampedParameter = Math.min(Math.max(parameter, 0), 1);
+  const knotParameter = low + clampedParameter * (high - low);
+
+  let segment = 0;
+  for (let index = domainLow; index < domainHigh; index += 1) {
+    if (
+      expandedKnots[index] <= knotParameter &&
+      knotParameter < expandedKnots[index + 1]
+    ) {
+      segment = index;
+      break;
+    }
+  }
+
+  if (segment === 0) {
+    segment = domainHigh - 1;
+  }
+
+  const points = controlPoints.map((point) => ({ ...point }));
+  for (let level = 1; level <= degree + 1; level += 1) {
+    for (let index = segment; index > segment - degree - 1 + level; index -= 1) {
+      const denominator = expandedKnots[index + degree + 1 - level] -
+        expandedKnots[index];
+      const alpha =
+        Math.abs(denominator) < EPSILON
+          ? 1
+          : (knotParameter - expandedKnots[index]) / denominator;
+      points[index] = interpolateVec3(points[index - 1], points[index], alpha);
+    }
+  }
+
+  return points[segment];
+}
+
+export function getBSplineCurveControlPoints(
+  curve: IfcBSplineCurveWithKnots,
+): Vec3[] {
+  return curve.controlPointsList.map(cartesianPointToVec3);
+}
+
+export function validateBSplineCurveWithKnots(
+  curve: IfcBSplineCurveWithKnots,
+): BSplineValidationResult {
+  const errors: string[] = [];
+  const degree = Math.floor(curve.degree);
+  const upKnots = curve.knots.length;
+  const upCp = curve.controlPointsList.length - 1;
+  const sum = curve.knotMultiplicities.reduce(
+    (total, multiplicity) => total + Math.floor(multiplicity),
+    0,
+  );
+
+  if (curve.knotMultiplicities.length !== curve.knots.length) {
+    errors.push(
+      "CorrespondingKnotLists: KnotMultiplicities and Knots must have the same number of elements.",
+    );
+  }
+
+  if (degree < 1) {
+    errors.push("ConsistentBSpline: Degree must be at least 1.");
+  }
+  if (upKnots < 2) {
+    errors.push("ConsistentBSpline: at least two distinct knots are required.");
+  }
+  if (upCp < degree) {
+    errors.push(
+      "ConsistentBSpline: the upper index on control points must be at least Degree.",
+    );
+  }
+  if (sum !== degree + upCp + 2) {
+    errors.push(
+      `ConsistentBSpline: sum of KnotMultiplicities must be ${degree + upCp + 2}, got ${sum}.`,
+    );
+  }
+
+  if (curve.knotMultiplicities.length > 0) {
+    const firstMultiplicity = Math.floor(curve.knotMultiplicities[0]);
+    if (firstMultiplicity < 1 || firstMultiplicity > degree + 1) {
+      errors.push(
+        `ConsistentBSpline: first knot multiplicity must be between 1 and ${degree + 1}.`,
+      );
+    }
+  }
+
+  for (let index = 1; index < upKnots; index += 1) {
+    const multiplicity = Math.floor(curve.knotMultiplicities[index] ?? 0);
+    if (multiplicity < 1) {
+      errors.push(
+        `ConsistentBSpline: knot multiplicity K${index + 1} must be at least 1.`,
+      );
+    }
+    if (curve.knots[index] <= curve.knots[index - 1]) {
+      errors.push(
+        `ConsistentBSpline: knot K${index + 1} must be greater than K${index}.`,
+      );
+    }
+    if (index < upKnots - 1 && multiplicity > degree) {
+      errors.push(
+        `ConsistentBSpline: interior knot multiplicity K${index + 1} must not exceed Degree (${degree}).`,
+      );
+    }
+    if (index === upKnots - 1 && multiplicity > degree + 1) {
+      errors.push(
+        `ConsistentBSpline: last knot multiplicity must not exceed Degree + 1 (${degree + 1}).`,
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function resolveBSplineCurveWithKnotsSegments(
+  curve: IfcBSplineCurveWithKnots,
+  options: BSplineCurveOptions = {},
+): ResolvedCurveSegment[] {
+  const validation = validateBSplineCurveWithKnots(curve);
+  if (!validation.valid) return [];
+
+  const controlPoints = getBSplineCurveControlPoints(curve);
+  const expandedKnots = expandKnots(curve.knotMultiplicities, curve.knots);
+  const segmentCount = Math.max(
+    1,
+    options.segmentCount ?? DEFAULT_BSPLINE_SEGMENTS,
+  );
+
+  const points: Vec3[] = [];
+  for (let index = 0; index <= segmentCount; index += 1) {
+    points.push(
+      evaluateBSpline(index / segmentCount, curve.degree, controlPoints, expandedKnots),
+    );
+  }
+
+  return [{ kind: "curve", points }];
+}

--- a/src/ifc/operations/curve-bspline.ts
+++ b/src/ifc/operations/curve-bspline.ts
@@ -115,6 +115,9 @@ export function validateBSplineCurveWithKnots(
     );
   }
 
+  if (!Number.isInteger(curve.degree)) {
+    errors.push("ConsistentBSpline: Degree must be an integer.");
+  }
   if (degree < 1) {
     errors.push("ConsistentBSpline: Degree must be at least 1.");
   }
@@ -175,6 +178,7 @@ export function resolveBSplineCurveWithKnotsSegments(
   const validation = validateBSplineCurveWithKnots(curve);
   if (!validation.valid) return [];
 
+  const degree = Math.floor(curve.degree);
   const controlPoints = getBSplineCurveControlPoints(curve);
   const expandedKnots = expandKnots(curve.knotMultiplicities, curve.knots);
   const segmentCount = Math.max(
@@ -185,7 +189,7 @@ export function resolveBSplineCurveWithKnotsSegments(
   const points: Vec3[] = [];
   for (let index = 0; index <= segmentCount; index += 1) {
     points.push(
-      evaluateBSpline(index / segmentCount, curve.degree, controlPoints, expandedKnots),
+      evaluateBSpline(index / segmentCount, degree, controlPoints, expandedKnots),
     );
   }
 

--- a/src/ifc/operations/curve.ts
+++ b/src/ifc/operations/curve.ts
@@ -1,6 +1,7 @@
 import { Color3, Mesh, MeshBuilder } from "@babylonjs/core";
 import type { Scene, StandardMaterial } from "@babylonjs/core";
 import type {
+  IfcBSplineCurveWithKnots,
   IfcCartesianPointList,
   IfcCircle,
   IfcClothoid,
@@ -14,6 +15,10 @@ import type {
 } from "../generated/schema.ts";
 import { ifcToBabylonVector } from "../../engine/ifc-coordinates.ts";
 import type { Vec3 } from "../../types.ts";
+import {
+  getBSplineCurveControlPoints,
+  resolveBSplineCurveWithKnotsSegments,
+} from "./curve-bspline.ts";
 import { resolveClothoidCurveSegments } from "./curve-clothoid.ts";
 import { resolveConicCurveSegment } from "./curve-conic.ts";
 import { cartesianPointToVec3, resolveLineCurveSegment } from "./curve-line.ts";
@@ -35,6 +40,7 @@ const DEFAULT_ARC_SEGMENTS = 32;
 const EPSILON = 1e-9;
 
 type RenderableCurve =
+  | IfcBSplineCurveWithKnots
   | IfcPolyline
   | IfcIndexedPolyCurve
   | IfcCircle
@@ -220,6 +226,8 @@ export function resolveSupportedCurveSegments(
       return resolvePolynomialCurveSegments(curve);
     case "IfcClothoid":
       return resolveClothoidCurveSegments(curve);
+    case "IfcBSplineCurveWithKnots":
+      return resolveBSplineCurveWithKnotsSegments(curve);
     default: {
       const _exhaustive: never = curve;
       throw new Error(`Curve type is not supported yet: ${String(_exhaustive)}`);
@@ -345,6 +353,45 @@ export function buildIndexedPolyCurvePointMarkers(
   radius = 0.12,
 ): Mesh[] {
   return getIndexedPolyCurveControlPoints(curve).map((point, index) => {
+    const marker = MeshBuilder.CreateSphere(
+      `${name}_${index}`,
+      { diameter: radius * 2, segments: 16 },
+      scene,
+    );
+    marker.position = ifcToBabylonVector(point);
+    marker.material = material;
+    return marker;
+  });
+}
+
+export function buildBSplineCurveControlPolygon(
+  scene: Scene,
+  curve: IfcBSplineCurveWithKnots,
+  name: string,
+  color = new Color3(0.75, 0.78, 0.82),
+): Mesh {
+  const controlPoints = getBSplineCurveControlPoints(curve);
+  if (controlPoints.length < 2) {
+    return new Mesh(`${name}_empty`, scene);
+  }
+
+  const lines = MeshBuilder.CreateLines(
+    name,
+    { points: controlPoints.map(ifcToBabylonVector) },
+    scene,
+  );
+  lines.color = color;
+  return lines;
+}
+
+export function buildBSplineCurvePointMarkers(
+  scene: Scene,
+  curve: IfcBSplineCurveWithKnots,
+  material: StandardMaterial,
+  name: string,
+  radius = 0.12,
+): Mesh[] {
+  return getBSplineCurveControlPoints(curve).map((point, index) => {
     const marker = MeshBuilder.CreateSphere(
       `${name}_${index}`,
       { diameter: radius * 2, segments: 16 },

--- a/src/ifc/samples/curve.bspline-with-knots.ts
+++ b/src/ifc/samples/curve.bspline-with-knots.ts
@@ -1,0 +1,106 @@
+import { Color3 } from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import type {
+  ExtrusionParams,
+  IfcAxis2Placement3D,
+  IfcProfileDef,
+  ParamValues,
+  PolynomialCoefficients,
+  SampleDef,
+  SweepViewState,
+  Vec3,
+} from "../../types.ts";
+import type {
+  IfcBSplineCurveWithKnots,
+  IfcIndexedPolyCurve,
+} from "../generated/schema.ts";
+import { getOrCreateSolidMaterial } from "../../engine/materials.ts";
+import {
+  buildBSplineCurveControlPolygon,
+  buildBSplineCurvePointMarkers,
+  buildSupportedCurve,
+} from "../operations/curve.ts";
+
+const DEFAULT_CONTROL_POINTS: Vec3[] = [
+  { x: -4, y: -1.2, z: 0 },
+  { x: -2.8, y: 1.4, z: 0.5 },
+  { x: -1.3, y: 2, z: 1.2 },
+  { x: 0.4, y: -0.8, z: 1.7 },
+  { x: 2.2, y: -1.5, z: 2.4 },
+  { x: 4, y: 1.1, z: 3 },
+];
+
+function toIfcBSplineCurveWithKnots(
+  controlPoints: Vec3[],
+): IfcBSplineCurveWithKnots {
+  return {
+    type: "IfcBSplineCurveWithKnots",
+    degree: 3,
+    controlPointsList: controlPoints.map((point) => ({
+      type: "IfcCartesianPoint",
+      coordinates: [point.x, point.y, point.z],
+    })),
+    curveForm: "UNSPECIFIED",
+    closedCurve: false,
+    selfIntersect: false,
+    knotMultiplicities: [4, 1, 1, 4],
+    knots: [0, 1, 2, 3],
+    knotSpec: "UNSPECIFIED",
+  };
+}
+
+export const curveBSplineWithKnotsSample: SampleDef = {
+  id: "curve-bspline-with-knots",
+  title: "B-Spline Curve With Knots (IfcBSplineCurveWithKnots)",
+  description:
+    "Inspect an IfcBSplineCurveWithKnots through editable control points, knot multiplicities, and distinct knot values.",
+  parameters: [],
+  steps: [
+    {
+      id: "curve",
+      label: "IfcBSplineCurveWithKnots",
+      description:
+        "ControlPointsList is shown as vertices, the control polygon joins them with straight lines, and the evaluated B-spline curve is drawn from the expanded knot vector.",
+    },
+  ],
+  bsplineCurveWithKnotsEditorConfig: {
+    defaultCurve: toIfcBSplineCurveWithKnots(DEFAULT_CONTROL_POINTS),
+    label: "IfcBSplineCurveWithKnots",
+  },
+  buildGeometry: (
+    scene: Scene,
+    _params: ParamValues,
+    _stepIndex: number,
+    _profile?: IfcProfileDef,
+    _path?: Vec3[],
+    _extrusion?: ExtrusionParams,
+    _placement?: IfcAxis2Placement3D,
+    _sweepView?: SweepViewState,
+    _indexedPolyCurve?: IfcIndexedPolyCurve,
+    _polynomialCoefficients?: PolynomialCoefficients,
+    bsplineCurve?: IfcBSplineCurveWithKnots,
+  ): Mesh[] => {
+    const curve =
+      bsplineCurve ?? toIfcBSplineCurveWithKnots(DEFAULT_CONTROL_POINTS);
+    const markerMaterial = getOrCreateSolidMaterial(
+      scene,
+      "bspline_control_point_marker",
+      new Color3(1, 0.58, 0.18),
+    );
+
+    return [
+      buildBSplineCurveControlPolygon(scene, curve, "bspline_control_polygon"),
+      ...buildBSplineCurvePointMarkers(
+        scene,
+        curve,
+        markerMaterial,
+        "bspline_control_point",
+      ),
+      ...buildSupportedCurve(scene, curve, "bspline_curve", {
+        curveColor: new Color3(0.2, 0.88, 0.95),
+      }),
+    ];
+  },
+  getIFCRepresentation: () =>
+    toIfcBSplineCurveWithKnots(DEFAULT_CONTROL_POINTS),
+};

--- a/src/pages/ExamplePage.ts
+++ b/src/pages/ExamplePage.ts
@@ -9,7 +9,10 @@ import type {
   SweepViewState,
   PolynomialCoefficients,
 } from "../types.ts";
-import type { IfcIndexedPolyCurve } from "../ifc/generated/schema.ts";
+import type {
+  IfcBSplineCurveWithKnots,
+  IfcIndexedPolyCurve,
+} from "../ifc/generated/schema.ts";
 import { SceneManager } from "../engine/scene.ts";
 import { ViewportCamera } from "../engine/viewport-camera.ts";
 import { ViewportControls } from "../ui/ViewportControls.ts";
@@ -18,6 +21,7 @@ import { Stepper } from "../ui/Stepper.ts";
 import { ProfileEditor } from "../ui/ProfileEditor.ts";
 import { PathEditor } from "../ui/PathEditor.ts";
 import { IndexedPolyCurveEditor } from "../ui/IndexedPolyCurveEditor.ts";
+import { BSplineCurveWithKnotsEditor } from "../ui/BSplineCurveWithKnotsEditor.ts";
 import { ExtrusionEditor } from "../ui/ExtrusionEditor.ts";
 import { PlacementEditor } from "../ui/PlacementEditor.ts";
 import { SweepViewToggles } from "../ui/SweepViewToggles.ts";
@@ -36,6 +40,8 @@ export class ExamplePage {
   private currentProfile: IfcProfileDef | undefined = undefined;
   private currentPath: Vec3[] | undefined = undefined;
   private currentIndexedPolyCurve: IfcIndexedPolyCurve | undefined = undefined;
+  private currentBSplineCurveWithKnots: IfcBSplineCurveWithKnots | undefined =
+    undefined;
   private currentExtrusion: ExtrusionParams | undefined = undefined;
   private currentPlacement: IfcAxis2Placement3D | undefined = undefined;
   private currentSweepView: SweepViewState | undefined = undefined;
@@ -71,6 +77,15 @@ export class ExamplePage {
         ) as IfcIndexedPolyCurve)
       : undefined;
 
+    this.currentBSplineCurveWithKnots =
+      sample.bsplineCurveWithKnotsEditorConfig
+        ? (JSON.parse(
+            JSON.stringify(
+              sample.bsplineCurveWithKnotsEditorConfig.defaultCurve,
+            ),
+          ) as IfcBSplineCurveWithKnots)
+        : undefined;
+
     // Seed extrusion from config default (if any)
     this.currentExtrusion = sample.extrusionEditorConfig
       ? (JSON.parse(
@@ -105,6 +120,9 @@ export class ExamplePage {
     const hasProfileEditor = Boolean(sample.profileEditorConfig);
     const hasPathEditor = Boolean(sample.pathEditorConfig);
     const hasIndexedPolyCurveEditor = Boolean(sample.indexedPolyCurveEditorConfig);
+    const hasBSplineCurveWithKnotsEditor = Boolean(
+      sample.bsplineCurveWithKnotsEditorConfig,
+    );
     const hasExtrusionEditor = Boolean(sample.extrusionEditorConfig);
     const hasPlacementEditor = Boolean(sample.placementEditorConfig);
     const hasPolynomialCoefficientEditor = Boolean(
@@ -154,9 +172,19 @@ export class ExamplePage {
                 : ""
             }
             ${
-              hasExtrusionEditor
+              hasBSplineCurveWithKnotsEditor
                 ? `
               <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor ? " left-panel-section-mt" : ""}" open>
+                <summary class="params-title">${sample.bsplineCurveWithKnotsEditorConfig!.label ?? "B-Spline Curve With Knots"}</summary>
+                <div class="left-collapsible-content" id="bspline-curve-with-knots-editor-panel"></div>
+              </details>
+            `
+                : ""
+            }
+            ${
+              hasExtrusionEditor
+                ? `
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasBSplineCurveWithKnotsEditor ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">${sample.extrusionEditorConfig!.label ?? "Extrusion"}</summary>
                 <div class="left-collapsible-content" id="extrusion-editor-panel"></div>
               </details>
@@ -176,7 +204,7 @@ export class ExamplePage {
             ${
               sample.parameters.length > 0
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasBSplineCurveWithKnotsEditor || hasExtrusionEditor || hasSweepToggles ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">Parameters</summary>
                 <div class="left-collapsible-content" id="param-panel"></div>
               </details>
@@ -186,7 +214,7 @@ export class ExamplePage {
             ${
               hasPolynomialCoefficientEditor
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}" open>
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasBSplineCurveWithKnotsEditor || hasExtrusionEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}" open>
                 <summary class="params-title">${sample.polynomialCoefficientEditorConfig!.label ?? "Coefficients"}</summary>
                 <div class="left-collapsible-content" id="polynomial-coefficient-editor-panel"></div>
               </details>
@@ -196,7 +224,7 @@ export class ExamplePage {
             ${
               hasPlacementEditor
                 ? `
-              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasExtrusionEditor || hasPolynomialCoefficientEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
+              <details class="left-collapsible${hasProfileEditor || hasPathEditor || hasIndexedPolyCurveEditor || hasBSplineCurveWithKnotsEditor || hasExtrusionEditor || hasPolynomialCoefficientEditor || hasSweepToggles || sample.parameters.length > 0 ? " left-panel-section-mt" : ""}">
                 <summary class="params-title">${sample.placementEditorConfig!.label ?? "Placement"}</summary>
                 <div class="left-collapsible-content" id="placement-editor-panel"></div>
               </details>
@@ -270,6 +298,23 @@ export class ExamplePage {
       );
       indexedPolyCurveEditor.onChange((curve) => {
         this.currentIndexedPolyCurve = curve;
+        this._scheduleRebuild(sample.debounceMs ?? 0);
+      });
+    }
+
+    const bsplineCurveWithKnotsEditorContainer = document.getElementById(
+      "bspline-curve-with-knots-editor-panel",
+    );
+    if (
+      bsplineCurveWithKnotsEditorContainer &&
+      sample.bsplineCurveWithKnotsEditorConfig
+    ) {
+      const bsplineCurveWithKnotsEditor = new BSplineCurveWithKnotsEditor(
+        bsplineCurveWithKnotsEditorContainer,
+        sample.bsplineCurveWithKnotsEditorConfig,
+      );
+      bsplineCurveWithKnotsEditor.onChange((curve) => {
+        this.currentBSplineCurveWithKnots = curve;
         this._scheduleRebuild(sample.debounceMs ?? 0);
       });
     }
@@ -390,6 +435,7 @@ export class ExamplePage {
       this.currentSweepView,
       this.currentIndexedPolyCurve,
       this.currentPolynomialCoefficients,
+      this.currentBSplineCurveWithKnots,
     );
 
     // Show local coordinate axes when a placement editor is active

--- a/src/style.css
+++ b/src/style.css
@@ -961,6 +961,83 @@ a.map-entity:hover {
   border-color: #4fc3f7;
 }
 
+/* B-Spline Curve With Knots Editor */
+.bspline-editor {
+  margin-bottom: 4px;
+}
+
+.bspline-section + .bspline-section {
+  margin-top: 10px;
+}
+
+.bspline-degree-row,
+.bspline-knot-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78em;
+}
+
+.bspline-degree-label {
+  color: #90caf9;
+  min-width: 58px;
+}
+
+.bspline-number-input {
+  width: 64px;
+  background: #0d1b2e;
+  border: 1px solid #1a2a4a;
+  border-radius: 3px;
+  color: #c0cce0;
+  padding: 2px 4px;
+  font-size: 0.82em;
+  font-family: monospace;
+}
+
+.bspline-number-input:focus {
+  outline: none;
+  border-color: #4fc3f7;
+}
+
+.bspline-points-list,
+.bspline-knots-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.bspline-knot-row {
+  display: grid;
+  grid-template-columns: 32px 14px 64px 14px 64px 22px;
+  background: #0a1424;
+  border: 1px solid #1a2a4a;
+  border-radius: 5px;
+  padding: 6px;
+}
+
+.bspline-validation {
+  border-radius: 4px;
+  font-size: 0.76em;
+  line-height: 1.35;
+  margin-top: 10px;
+  padding: 6px 8px;
+}
+
+.bspline-validation-ok {
+  background: #0d2a1a;
+  border: 1px solid #2e7d32;
+  color: #8fd694;
+}
+
+.bspline-validation-error {
+  background: #2a1218;
+  border: 1px solid #8a2a3a;
+  color: #ff9aa8;
+}
+
 /* Extrusion Editor */
 .extrusion-editor {
   margin-bottom: 4px;

--- a/src/style.css
+++ b/src/style.css
@@ -970,8 +970,7 @@ a.map-entity:hover {
   margin-top: 10px;
 }
 
-.bspline-degree-row,
-.bspline-knot-row {
+.bspline-degree-row {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { Scene } from "@babylonjs/core";
 import type { Mesh } from "@babylonjs/core";
 import type {
   IfcAreaParameterizedProfileDef,
+  IfcBSplineCurveWithKnots,
   IfcIndexedPolyCurve,
   IfcProfileTypeEnum,
 } from "./ifc/generated/schema.ts";
@@ -216,6 +217,14 @@ export interface IndexedPolyCurveEditorConfig {
   label?: string;
 }
 
+/** Configuration for editing IfcBSplineCurveWithKnots parameters. */
+export interface BSplineCurveWithKnotsEditorConfig {
+  /** Initial IFC B-spline curve, including control points and knot data. */
+  defaultCurve: IfcBSplineCurveWithKnots;
+  /** Optional label shown above the editor. */
+  label?: string;
+}
+
 /** Extrusion parameters edited as a single reusable unit. */
 export interface ExtrusionParams {
   /** Positive distance to extrude along extrudedDirection. */
@@ -298,6 +307,11 @@ export interface SampleDef {
    */
   indexedPolyCurveEditorConfig?: IndexedPolyCurveEditorConfig;
   /**
+   * When set, ExamplePage renders a BSplineCurveWithKnots editor. The current
+   * IfcBSplineCurveWithKnots is forwarded to buildGeometry as the optional eleventh argument.
+   */
+  bsplineCurveWithKnotsEditorConfig?: BSplineCurveWithKnotsEditorConfig;
+  /**
    * When set, ExamplePage renders an ExtrusionEditor widget that lets the user
    * edit depth and extrudedDirection. The current ExtrusionParams is forwarded
    * to buildGeometry as the optional sixth argument.
@@ -331,6 +345,7 @@ export interface SampleDef {
     sweepView?: SweepViewState,
     indexedPolyCurve?: IfcIndexedPolyCurve,
     polynomialCoefficients?: PolynomialCoefficients,
+    bsplineCurveWithKnots?: IfcBSplineCurveWithKnots,
   ) => Mesh[];
   getIFCRepresentation: (params: ParamValues) => object;
 }

--- a/src/ui/BSplineCurveWithKnotsEditor.ts
+++ b/src/ui/BSplineCurveWithKnotsEditor.ts
@@ -1,0 +1,340 @@
+import type { BSplineCurveWithKnotsEditorConfig, Vec3 } from "../types.ts";
+import type { IfcBSplineCurveWithKnots } from "../ifc/generated/schema.ts";
+import { validateBSplineCurveWithKnots } from "../ifc/operations/curve-bspline.ts";
+
+const DEFAULT_COORD_STEP = 0.5;
+const DEFAULT_KNOT_STEP = 0.5;
+
+function cloneCurve(
+  curve: IfcBSplineCurveWithKnots,
+): IfcBSplineCurveWithKnots {
+  return {
+    ...curve,
+    controlPointsList: curve.controlPointsList.map((point) => ({
+      type: "IfcCartesianPoint",
+      coordinates: [...point.coordinates],
+    })),
+    knotMultiplicities: [...curve.knotMultiplicities],
+    knots: [...curve.knots],
+  };
+}
+
+function pointToVec3(point: { coordinates: number[] }): Vec3 {
+  return {
+    x: point.coordinates[0] ?? 0,
+    y: point.coordinates[1] ?? 0,
+    z: point.coordinates[2] ?? 0,
+  };
+}
+
+function vec3ToPoint(point: Vec3) {
+  return {
+    type: "IfcCartesianPoint" as const,
+    coordinates: [point.x, point.y, point.z],
+  };
+}
+
+export class BSplineCurveWithKnotsEditor {
+  private container: HTMLElement;
+  private curve: IfcBSplineCurveWithKnots;
+  private changeCallbacks: Array<(curve: IfcBSplineCurveWithKnots) => void> = [];
+  private validationPanel: HTMLElement | undefined = undefined;
+
+  constructor(
+    container: HTMLElement,
+    config: BSplineCurveWithKnotsEditorConfig,
+  ) {
+    this.container = container;
+    this.curve = cloneCurve(config.defaultCurve);
+    this._render();
+  }
+
+  getCurve(): IfcBSplineCurveWithKnots {
+    return cloneCurve(this.curve);
+  }
+
+  onChange(callback: (curve: IfcBSplineCurveWithKnots) => void): void {
+    this.changeCallbacks.push(callback);
+  }
+
+  private get points(): Vec3[] {
+    return this.curve.controlPointsList.map(pointToVec3);
+  }
+
+  private _setPoints(points: Vec3[]): void {
+    this.curve.controlPointsList = points.map(vec3ToPoint);
+  }
+
+  private _notify(): void {
+    const copy = this.getCurve();
+    for (const cb of this.changeCallbacks) cb(copy);
+  }
+
+  private _render(): void {
+    this.container.innerHTML = "";
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "bspline-editor";
+
+    const basisSection = document.createElement("div");
+    basisSection.className = "bspline-section";
+    basisSection.appendChild(this._buildSectionTitle("Basis"));
+    basisSection.appendChild(this._buildDegreeRow());
+    wrapper.appendChild(basisSection);
+
+    const pointsSection = document.createElement("div");
+    pointsSection.className = "bspline-section";
+    pointsSection.appendChild(this._buildSectionTitle("ControlPointsList"));
+    pointsSection.appendChild(this._buildPointsList());
+    pointsSection.appendChild(this._buildAddPointButton());
+    wrapper.appendChild(pointsSection);
+
+    const knotsSection = document.createElement("div");
+    knotsSection.className = "bspline-section";
+    knotsSection.appendChild(this._buildSectionTitle("Knots"));
+    knotsSection.appendChild(this._buildKnotList());
+    knotsSection.appendChild(this._buildAddKnotButton());
+    wrapper.appendChild(knotsSection);
+
+    this.validationPanel = this._buildValidationPanel();
+    wrapper.appendChild(this.validationPanel);
+
+    this.container.appendChild(wrapper);
+  }
+
+  private _buildSectionTitle(label: string): HTMLElement {
+    const title = document.createElement("div");
+    title.className = "indexed-polycurve-section-title";
+    title.textContent = label;
+    return title;
+  }
+
+  private _buildDegreeRow(): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "bspline-degree-row";
+
+    const label = document.createElement("label");
+    label.className = "bspline-degree-label";
+    label.textContent = "Degree";
+    row.appendChild(label);
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = "1";
+    input.step = "1";
+    input.className = "bspline-number-input";
+    input.value = String(this.curve.degree);
+    input.addEventListener("input", () => {
+      const parsed = Number(input.value);
+      if (!Number.isFinite(parsed)) return;
+      this.curve.degree = Math.max(1, Math.round(parsed));
+      input.value = String(this.curve.degree);
+      this._syncValidation();
+      this._notify();
+    });
+    row.appendChild(input);
+
+    return row;
+  }
+
+  private _buildPointsList(): HTMLElement {
+    const list = document.createElement("div");
+    list.className = "bspline-points-list";
+    this.points.forEach((point, index) => {
+      list.appendChild(this._buildPointRow(point, index));
+    });
+    return list;
+  }
+
+  private _buildPointRow(point: Vec3, index: number): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "path-point-row";
+
+    const idx = document.createElement("span");
+    idx.className = "point-index";
+    idx.textContent = `P${index + 1}`;
+    row.appendChild(idx);
+
+    const coords: Array<{ label: string; axis: keyof Vec3 }> = [
+      { label: "x", axis: "x" },
+      { label: "y", axis: "y" },
+      { label: "z", axis: "z" },
+    ];
+
+    for (const { label, axis } of coords) {
+      const coordLabel = document.createElement("span");
+      coordLabel.className = "point-coord-label";
+      coordLabel.textContent = label;
+      row.appendChild(coordLabel);
+
+      const input = document.createElement("input");
+      input.type = "number";
+      input.className = "point-coord-input";
+      input.value = String(point[axis]);
+      input.step = String(DEFAULT_COORD_STEP);
+      input.addEventListener("input", () => {
+        const parsed = Number(input.value);
+        if (!Number.isFinite(parsed)) return;
+
+        const points = this.points;
+        points[index] = { ...points[index], [axis]: parsed };
+        this._setPoints(points);
+        this._syncValidation();
+        this._notify();
+      });
+      row.appendChild(input);
+    }
+
+    if (this.curve.controlPointsList.length > 2) {
+      const del = document.createElement("button");
+      del.className = "point-delete-btn";
+      del.title = "Remove control point";
+      del.textContent = "x";
+      del.addEventListener("click", () => {
+        const points = this.points;
+        points.splice(index, 1);
+        this._setPoints(points);
+        this._refreshAndNotify();
+      });
+      row.appendChild(del);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    return row;
+  }
+
+  private _buildAddPointButton(): HTMLElement {
+    const addBtn = document.createElement("button");
+    addBtn.className = "path-add-point-btn";
+    addBtn.textContent = "+ Add control point";
+    addBtn.addEventListener("click", () => {
+      const points = this.points;
+      const last = points.at(-1) ?? { x: 0, y: 0, z: 0 };
+      points.push({ x: last.x + 1, y: last.y, z: last.z });
+      this._setPoints(points);
+      this._refreshAndNotify();
+    });
+    return addBtn;
+  }
+
+  private _buildKnotList(): HTMLElement {
+    const list = document.createElement("div");
+    list.className = "bspline-knots-list";
+    this.curve.knots.forEach((_knot, index) => {
+      list.appendChild(this._buildKnotRow(index));
+    });
+    return list;
+  }
+
+  private _buildKnotRow(index: number): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "bspline-knot-row";
+
+    const idx = document.createElement("span");
+    idx.className = "indexed-segment-label";
+    idx.textContent = `K${index + 1}`;
+    row.appendChild(idx);
+
+    const multiplicityLabel = document.createElement("span");
+    multiplicityLabel.className = "point-coord-label";
+    multiplicityLabel.textContent = "m";
+    row.appendChild(multiplicityLabel);
+
+    const multiplicityInput = document.createElement("input");
+    multiplicityInput.type = "number";
+    multiplicityInput.min = "1";
+    multiplicityInput.step = "1";
+    multiplicityInput.className = "bspline-number-input";
+    multiplicityInput.value = String(this.curve.knotMultiplicities[index] ?? 1);
+    multiplicityInput.addEventListener("input", () => {
+      const parsed = Number(multiplicityInput.value);
+      if (!Number.isFinite(parsed)) return;
+      this.curve.knotMultiplicities[index] = Math.max(1, Math.round(parsed));
+      multiplicityInput.value = String(this.curve.knotMultiplicities[index]);
+      this._syncValidation();
+      this._notify();
+    });
+    row.appendChild(multiplicityInput);
+
+    const knotLabel = document.createElement("span");
+    knotLabel.className = "point-coord-label";
+    knotLabel.textContent = "u";
+    row.appendChild(knotLabel);
+
+    const knotInput = document.createElement("input");
+    knotInput.type = "number";
+    knotInput.step = String(DEFAULT_KNOT_STEP);
+    knotInput.className = "bspline-number-input";
+    knotInput.value = String(this.curve.knots[index]);
+    knotInput.addEventListener("input", () => {
+      const parsed = Number(knotInput.value);
+      if (!Number.isFinite(parsed)) return;
+      this.curve.knots[index] = parsed;
+      this._syncValidation();
+      this._notify();
+    });
+    row.appendChild(knotInput);
+
+    if (this.curve.knots.length > 2) {
+      const del = document.createElement("button");
+      del.className = "point-delete-btn";
+      del.title = "Remove knot";
+      del.textContent = "x";
+      del.addEventListener("click", () => {
+        this.curve.knotMultiplicities.splice(index, 1);
+        this.curve.knots.splice(index, 1);
+        this._refreshAndNotify();
+      });
+      row.appendChild(del);
+    } else {
+      const placeholder = document.createElement("span");
+      placeholder.className = "point-delete-placeholder";
+      row.appendChild(placeholder);
+    }
+
+    return row;
+  }
+
+  private _buildAddKnotButton(): HTMLElement {
+    const addBtn = document.createElement("button");
+    addBtn.className = "path-add-point-btn";
+    addBtn.textContent = "+ Add knot";
+    addBtn.addEventListener("click", () => {
+      const last = this.curve.knots.at(-1) ?? 0;
+      this.curve.knots.push(last + 1);
+      this.curve.knotMultiplicities.push(1);
+      this._refreshAndNotify();
+    });
+    return addBtn;
+  }
+
+  private _buildValidationPanel(): HTMLElement {
+    const panel = document.createElement("div");
+    panel.className = "bspline-validation";
+    this._syncValidation(panel);
+    return panel;
+  }
+
+  private _syncValidation(panel = this.validationPanel): void {
+    if (!panel) return;
+
+    const validation = validateBSplineCurveWithKnots(this.curve);
+    panel.classList.toggle("bspline-validation-ok", validation.valid);
+    panel.classList.toggle("bspline-validation-error", !validation.valid);
+
+    if (validation.valid) {
+      panel.textContent = "ConsistentBSpline: valid";
+      return;
+    }
+
+    panel.textContent = validation.errors.join(" ");
+  }
+
+  private _refreshAndNotify(): void {
+    this._render();
+    this._notify();
+  }
+}

--- a/src/ui/BSplineCurveWithKnotsEditor.ts
+++ b/src/ui/BSplineCurveWithKnotsEditor.ts
@@ -189,7 +189,7 @@ export class BSplineCurveWithKnotsEditor {
       const del = document.createElement("button");
       del.className = "point-delete-btn";
       del.title = "Remove control point";
-      del.textContent = "x";
+      del.textContent = "×";
       del.addEventListener("click", () => {
         const points = this.points;
         points.splice(index, 1);
@@ -282,7 +282,7 @@ export class BSplineCurveWithKnotsEditor {
       const del = document.createElement("button");
       del.className = "point-delete-btn";
       del.title = "Remove knot";
-      del.textContent = "x";
+      del.textContent = "×";
       del.addEventListener("click", () => {
         this.curve.knotMultiplicities.splice(index, 1);
         this.curve.knots.splice(index, 1);


### PR DESCRIPTION
## Summary

Adds support for an `IfcBSplineCurveWithKnots` sample in the playground, including route registration, curve operation wiring, and an interactive editor for control points, knot multiplicities, and knot values.

## Changes

- Add B-spline curve generation helpers and operation handling.
- Add a sample definition for `IfcBSplineCurveWithKnots`.
- Add a dedicated editor UI for curve degree, control points, knots, and multiplicities.
- Register the new sample in app routes and display metadata.

## Validation

- `bun run build`